### PR TITLE
Expand CI test coverage

### DIFF
--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -1,4 +1,4 @@
-name: Test Dotfiles
+name: Full Integration Test
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-setup:
+  full-integration-test:
     runs-on: macos-latest
 
     steps:

--- a/lib/dotfiles/steps/set_fish_default_shell_step.rb
+++ b/lib/dotfiles/steps/set_fish_default_shell_step.rb
@@ -9,11 +9,19 @@ class Dotfiles::Step::SetFishDefaultShellStep < Dotfiles::Step
 
     unless File.readlines("/etc/shells").any? { |line| line.strip == fish_path }
       debug "Adding Fish to allowed shells..."
-      execute("echo #{fish_path} | sudo tee -a /etc/shells", sudo: true)
+      if ci_or_noninteractive?
+        debug "Skipping adding Fish to /etc/shells in CI (requires sudo)"
+      else
+        execute("echo #{fish_path} | sudo tee -a /etc/shells", sudo: true)
+      end
     end
 
     debug "Changing default shell to Fish..."
-    execute("chsh -s #{fish_path}")
+    if ci_or_noninteractive?
+      debug "Skipping chsh in CI (would require user password)"
+    else
+      execute("chsh -s #{fish_path}")
+    end
   end
 
   def complete?

--- a/lib/dotfiles/steps/vscode_configuration_step.rb
+++ b/lib/dotfiles/steps/vscode_configuration_step.rb
@@ -15,12 +15,10 @@ class Dotfiles::Step::VSCodeConfigurationStep < Dotfiles::Step
     @system.cp(dotfiles_source("vscode_settings"), vscode_dir)
     @system.cp(dotfiles_source("vscode_keybindings"), vscode_dir)
 
-    install_vscode_extensions
+    install_vscode_extensions unless ci_or_noninteractive?
   end
 
   def complete?
-    return true if ci_or_noninteractive?
-
     vscode_settings = app_path("vscode_settings")
     vscode_keybindings = app_path("vscode_keybindings")
 

--- a/test/dotfiles/steps/vscode_configuration_step_test.rb
+++ b/test/dotfiles/steps/vscode_configuration_step_test.rb
@@ -7,11 +7,11 @@ class VSCodeConfigurationStepTest < Minitest::Test
     assert_includes deps, Dotfiles::Step::CloneDotfilesStep
   end
 
-  def test_complete_in_ci
+  def test_not_complete_without_files
     ENV["CI"] = "true"
 
     step = create_step(Dotfiles::Step::VSCodeConfigurationStep)
-    assert step.complete?
+    refute step.complete?
   ensure
     ENV.delete("CI")
   end


### PR DESCRIPTION
## Background
This PR aims to increase the reliability and coverage of our CI testing by adapting existing steps to function correctly within a non-interactive environment.

Closes #5 

## Changes
- Renamed `.github/workflows/test-setup.yml` to `.github/workflows/full-integration-test.yml` and updated the job name for clarity.
- Modified `lib/dotfiles/steps/set_fish_default_shell_step.rb`:
  - Added conditional logic to skip `sudo tee -a /etc/shells` and `chsh -s` when `ci_or_noninteractive?` is true.
  - Logs these skips with explanations.
- Modified `lib/dotfiles/steps/vscode_configuration_step.rb`:
  - Removed early `return true` in `complete?` for CI environments.
  - Added conditional logic to skip `install_vscode_extensions` when `ci_or_noninteractive?` is true.
- Updated `test/dotfiles/steps/vscode_configuration_step_test.rb` to assert that the step is not complete without files in CI.

## Testing
- [ ] Manually verify workflow name change in GitHub Actions.
- [ ] Observe logs for `set_fish_default_shell_step.rb` and `vscode_configuration_step.rb` in a CI run to confirm skips and explanations.
- [ ] Ensure VSCode configuration files are copied in CI.
