### PR TITLE
Add gum confirmation to dotfiles updater

### DIFF
--- a/lib/dotfiles/updater.rb
+++ b/lib/dotfiles/updater.rb
@@ -50,6 +50,8 @@ class Dotfiles
       system("git add -A")
       system("git diff --cached --stat")
 
+      return puts "Commit cancelled." unless system("gum confirm 'Proceed with commit?'")
+
       gc_ai_flags = ENV["GIT_COMMIT_FLAGS"] || ""
       gc_ai_cmd = "fish -c 'gc-ai #{gc_ai_flags}'"
       git_commit_cmd = "git commit #{gc_ai_flags} -m 'Update dotfiles from system'"


### PR DESCRIPTION
## Background
Enhance the dotfiles update process by adding an interactive confirmation step before committing changes.

## Changes
- Modified `lib/dotfiles/updater.rb`:
  - Added `gum confirm 'Proceed with commit?'` at line 53.
  - The script now checks the return value of `gum confirm`.
  - If the user cancels the confirmation, it prints "Commit cancelled." and exits.

## Testing
- [ ] Run `dotfiles update` and confirm the `gum` prompt appears.
- [ ] Test cancelling the commit with 'N' or pressing Enter. Verify "Commit cancelled." is displayed.
- [ ] Test proceeding with the commit with 'Y'. Verify the commit and push actions continue.
