### PR TITLE
Fix: Update Brew Packages depends on Update Homebrew

### DIFF
--- a/lib/dotfiles/steps/install_brew_packages_step.rb
+++ b/lib/dotfiles/steps/install_brew_packages_step.rb
@@ -1,6 +1,6 @@
 class Dotfiles::Step::InstallBrewPackagesStep < Dotfiles::Step
   def self.depends_on
-    [Dotfiles::Step::InstallHomebrewStep]
+    [Dotfiles::Step::UpdateHomebrewStep]
   end
 
   def initialize(**kwargs)


### PR DESCRIPTION
## Background
The `install_brew_packages_step.rb` incorrectly depended on `install_homebrew_step.rb`. For correct functionality, it should depend on `update_homebrew_step.rb`.

## Changes
- Modified `lib/dotfiles/steps/install_brew_packages_step.rb`: Changed the `depends_on` class method to return `[Dotfiles::Step::UpdateHomebrewStep]` instead of `[Dotfiles::Step::InstallHomebrewStep]`.

## Testing
- [ ] Verify that installing brew packages now correctly runs after `update_homebrew_step`.
