### PR TITLE
Rename dot utility to dotf

### DIFF
--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -29,8 +29,8 @@ jobs:
         NONINTERACTIVE: true
       run: |
         cd ${{ github.workspace }}
-        chmod +x bin/dot
-        ./bin/dot run 2>&1 | tee output.log
+        chmod +x bin/dotf
+        ./bin/dotf run 2>&1 | tee output.log
 
     - name: Check for success message
       run: |

--- a/README.md
+++ b/README.md
@@ -12,26 +12,26 @@ Personal configuration files for my development environment.
 2. Run the setup:
    ```bash
    cd ~/.dotfiles
-   ./bin/dot run
+   ./bin/dotf run
    ```
 
    The script automatically detects your Ruby version and bootstraps a modern Ruby environment if needed.
 
    To see detailed output during installation:
    ```bash
-   DEBUG=true ./bin/dot run
+   DEBUG=true ./bin/dotf run
    ```
 
 ## Usage
 
 ```bash
-dot <command>
+dotf <command>
 ```
 
 **Commands:**
-- `dot run` - Set up development environment. Idempotent - safe to run on an already-configured system. Only runs steps that haven't been completed.
-- `dot update` - Update dotfiles from the system
-- `dot help` - Show help message
+- `dotf run` - Set up development environment. Idempotent - safe to run on an already-configured system. Only runs steps that haven't been completed.
+- `dotf update` - Update dotfiles from the system
+- `dotf help` - Show help message
 
 ## How It Works: Steps
 

--- a/bin/dotf
+++ b/bin/dotf
@@ -96,7 +96,7 @@ check_for_updates() {
 
     if [ "$LOCAL_MAIN" != "$REMOTE_MAIN" ]; then
         echo ""
-        echo "📦 Updates available! Run 'dot update' to pull the latest changes."
+        echo "📦 Updates available! Run 'dotf update' to pull the latest changes."
     fi
 }
 
@@ -138,9 +138,9 @@ cmd_update() {
 
 cmd_help() {
     cat <<EOF
-dot - Dotfiles management tool
+dotf - Dotfiles management tool
 
-Usage: dot <command> [options]
+Usage: dotf <command> [options]
 
 Commands:
   run       Set up development environment from scratch
@@ -152,11 +152,11 @@ Options (for update command):
   --no-verify      Skip git pre-commit and commit-msg hooks
 
 Examples:
-  dot run                              # Initial setup
-  dot update                           # Update dotfiles
-  dot update --no-gpg-sign             # Update without GPG signing
-  dot update --no-gpg-sign --no-verify # Update without GPG or hooks
-  DEBUG=true dot run                   # Run with debug output
+  dotf run                              # Initial setup
+  dotf update                           # Update dotfiles
+  dotf update --no-gpg-sign             # Update without GPG signing
+  dotf update --no-gpg-sign --no-verify # Update without GPG or hooks
+  DEBUG=true dotf run                   # Run with debug output
 EOF
 }
 

--- a/docs/implementing-steps.md
+++ b/docs/implementing-steps.md
@@ -43,7 +43,7 @@ end
 
 ### `update` (optional)
 
-Syncs configuration from the system back into the dotfiles repository. Implement this to support the `dot update` command.
+Syncs configuration from the system back into the dotfiles repository. Implement this to support the `dotf update` command.
 
 ```ruby
 def update


### PR DESCRIPTION
## Summary

- Renames the `bin/dot` script to `bin/dotf`
- Updates all documentation references from `dot` to `dotf` in README.md and implementing-steps.md
- Updates GitHub Actions workflow to use `bin/dotf`
- Updates help text and usage examples in the script itself

## Test plan

- [ ] Verify `./bin/dotf run` executes successfully
- [ ] Verify `./bin/dotf update` works as expected
- [ ] Verify `./bin/dotf help` displays correct usage information
- [ ] Verify CI workflow runs successfully with the new binary name

🤖 Generated with [Claude Code](https://claude.com/claude-code)