### PR TITLE
Change UpdateMacOSStep to notify instead of executing updates

### DIFF
--- a/lib/dotfiles/steps/update_macos_step.rb
+++ b/lib/dotfiles/steps/update_macos_step.rb
@@ -8,8 +8,13 @@ class Dotfiles::Step::UpdateMacOSStep < Dotfiles::Step
   end
 
   def run
-    debug "User has admin rights, checking for macOS updates..."
-    execute("softwareupdate -i --recommended", sudo: true, quiet: true)
+    updates = minor_updates_available
+    update_list = updates.map { |id| "  • #{id}" }.join("\n")
+
+    add_notice(
+      title: "macOS Updates Available",
+      message: "The following macOS updates are available:\n#{update_list}\n\nTo install updates:\n  • Open System Settings → General → Software Update\n  • Or run: sudo softwareupdate -i --recommended"
+    )
   end
 
   def complete?

--- a/test/dotfiles/steps/update_macos_step_test.rb
+++ b/test/dotfiles/steps/update_macos_step_test.rb
@@ -50,6 +50,15 @@ class UpdateMacOSStepTest < Minitest::Test
     refute @step.complete?
   end
 
+  def test_run_adds_notice_with_available_updates
+    stub_admin_with_updates
+    @step.run
+
+    assert_equal 1, @step.notices.length
+    assert_equal "macOS Updates Available", @step.notices.first[:title]
+    assert_includes @step.notices.first[:message], "MSU_UPDATE_123_minor"
+  end
+
   private
 
   def stub_plist
@@ -57,20 +66,20 @@ class UpdateMacOSStepTest < Minitest::Test
     @fake_system.stub_file_content(plist_path, "plist")
   end
 
-  def stub_updates_available
+  def stub_plist_updates(has_updates)
     stub_plist
     plist_path = "/Library/Preferences/com.apple.SoftwareUpdate.plist"
     command = "defaults read #{plist_path} RecommendedUpdates 2>/dev/null"
-    output = ['Identifier = "MSU_UPDATE_123_minor"', 0]
+    output = has_updates ? ['Identifier = "MSU_UPDATE_123_minor"', 0] : ["no updates", 1]
     @fake_system.stub_execute_result(command, output)
   end
 
+  def stub_updates_available
+    stub_plist_updates(true)
+  end
+
   def stub_no_updates
-    stub_plist
-    plist_path = "/Library/Preferences/com.apple.SoftwareUpdate.plist"
-    command = "defaults read #{plist_path} RecommendedUpdates 2>/dev/null"
-    output = ["no updates", 1]
-    @fake_system.stub_execute_result(command, output)
+    stub_plist_updates(false)
   end
 
   def stub_admin_with_updates
@@ -83,17 +92,19 @@ class UpdateMacOSStepTest < Minitest::Test
     stub_no_updates
   end
 
-  def stub_updates_with_last_check
-    stub_updates_available
+  def stub_last_check
     plist_path = "/Library/Preferences/com.apple.SoftwareUpdate.plist"
     command = "defaults read #{plist_path} LastBackgroundSuccessfulDate 2>/dev/null"
     @fake_system.stub_execute_result(command, ["2024-01-01", 0])
   end
 
+  def stub_updates_with_last_check
+    stub_updates_available
+    stub_last_check
+  end
+
   def stub_no_updates_with_last_check
     stub_no_updates
-    plist_path = "/Library/Preferences/com.apple.SoftwareUpdate.plist"
-    command = "defaults read #{plist_path} LastBackgroundSuccessfulDate 2>/dev/null"
-    @fake_system.stub_execute_result(command, ["2024-01-01", 0])
+    stub_last_check
   end
 end


### PR DESCRIPTION
## Summary

Addresses #61 by converting UpdateMacOSStep from executing `softwareupdate -i --recommended` to adding a notice that informs users about available updates.

- Modified `run()` method to call `add_notice()` instead of `execute()`
- Notice includes list of available minor updates and instructions for manual installation
- Users can choose to install updates via System Settings or terminal command
- Refactored test helper methods to reduce code duplication (flay score: 68 → 0)

## Test plan

- All existing tests pass (10 tests for UpdateMacOSStep, 76 total)
- Added new test `test_run_adds_notice_with_available_updates` to verify notice functionality
- Verified notice includes update identifiers and correct title
- Lint checks pass (standardrb, flog, flay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)