### PR TITLE
Add ConfigureScreenshotsStep to set screenshot save location

### DIFF
--- a/config/screenshots.yml
+++ b/config/screenshots.yml
@@ -1,0 +1,4 @@
+---
+screenshot_settings:
+  com.apple.screencapture:
+    location: ~/Documents/Inbox

--- a/lib/dotfiles/steps/configure_screenshots_step.rb
+++ b/lib/dotfiles/steps/configure_screenshots_step.rb
@@ -1,0 +1,34 @@
+class Dotfiles::Step::ConfigureScreenshotsStep < Dotfiles::Step
+  include Dotfiles::Step::Defaultable
+
+  def self.depends_on
+    [Dotfiles::Step::CreateStandardFoldersStep]
+  end
+
+  def run
+    run_defaults_write
+    execute("killall SystemUIServer")
+  end
+
+  def complete?
+    setting_entries.all? do |domain, key, expected_value|
+      defaults_read_equals?(build_read_command(domain, key), expected_value)
+    end
+  end
+
+  def update
+    update_defaults_config("screenshot_settings", "screenshots.yml")
+  end
+
+  private
+
+  def screenshot_settings
+    @config.load_config("screenshots.yml").fetch("screenshot_settings", {})
+  end
+
+  def setting_entries
+    screenshot_settings.flat_map do |domain, settings|
+      settings.map { |key, value| [domain, key, value] }
+    end
+  end
+end

--- a/lib/dotfiles/steps/configure_trackpad_step.rb
+++ b/lib/dotfiles/steps/configure_trackpad_step.rb
@@ -2,10 +2,7 @@ class Dotfiles::Step::ConfigureTrackpadStep < Dotfiles::Step
   include Dotfiles::Step::Defaultable
 
   def run
-    setting_entries.each do |domain, key, value|
-      domain_flag = domain_flag_for(domain)
-      execute("defaults write #{domain_flag} #{key} -int #{value}")
-    end
+    run_defaults_write
   end
 
   def complete?

--- a/lib/dotfiles/steps/disable_animations_step.rb
+++ b/lib/dotfiles/steps/disable_animations_step.rb
@@ -2,11 +2,7 @@ class Dotfiles::Step::DisableAnimationsStep < Dotfiles::Step
   include Dotfiles::Step::Defaultable
 
   def run
-    setting_entries.each do |domain, key, value|
-      domain_flag = domain_flag_for(domain)
-      type_flag = type_flag_for(value)
-      execute("defaults write #{domain_flag} #{key} #{type_flag} #{value}")
-    end
+    run_defaults_write
     execute("killall Dock")
     execute("killall Finder")
   end
@@ -30,17 +26,6 @@ class Dotfiles::Step::DisableAnimationsStep < Dotfiles::Step
   def setting_entries
     animation_settings.flat_map do |domain, settings|
       settings.map { |key, value| [domain, key, value] }
-    end
-  end
-
-  def type_flag_for(value)
-    case value
-    when 0, 1
-      "-int"
-    when Float
-      "-float"
-    else
-      "-int"
     end
   end
 end

--- a/test/dotfiles/steps/configure_screenshots_step_test.rb
+++ b/test/dotfiles/steps/configure_screenshots_step_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+class ConfigureScreenshotsStepTest < Minitest::Test
+  def setup
+    super
+    stub_screenshots_config
+  end
+
+  def stub_screenshots_config
+    config_content = <<~YAML
+      screenshot_settings:
+        com.apple.screencapture:
+          location: ~/Documents/Inbox
+    YAML
+
+    @fake_system.stub_file_content("#{@dotfiles_dir}/config/screenshots.yml", config_content)
+  end
+
+  def test_step_exists
+    step = create_step(Dotfiles::Step::ConfigureScreenshotsStep)
+    assert_instance_of Dotfiles::Step::ConfigureScreenshotsStep, step
+  end
+
+  def test_depends_on_create_standard_folders_step
+    dependencies = Dotfiles::Step::ConfigureScreenshotsStep.depends_on
+    assert_includes dependencies, Dotfiles::Step::CreateStandardFoldersStep
+  end
+
+  def test_runs_defaults_write_command_for_location
+    step = create_step(Dotfiles::Step::ConfigureScreenshotsStep)
+    step.run
+
+    assert @fake_system.received_operation?(:execute, "defaults write com.apple.screencapture location -string ~/Documents/Inbox", {quiet: true})
+  end
+
+  def test_restarts_system_ui_server
+    step = create_step(Dotfiles::Step::ConfigureScreenshotsStep)
+    step.run
+
+    assert @fake_system.received_operation?(:execute, "killall SystemUIServer", {quiet: true})
+  end
+
+  def test_complete_when_location_matches
+    step = create_step(Dotfiles::Step::ConfigureScreenshotsStep)
+    @fake_system.stub_command("defaults read com.apple.screencapture location", "~/Documents/Inbox", exit_status: 0)
+
+    assert step.complete?
+  end
+
+  def test_incomplete_when_location_differs
+    step = create_step(Dotfiles::Step::ConfigureScreenshotsStep)
+    @fake_system.stub_command("defaults read com.apple.screencapture location", "~/Desktop", exit_status: 0)
+
+    refute step.complete?
+  end
+
+  def test_incomplete_when_location_not_set
+    step = create_step(Dotfiles::Step::ConfigureScreenshotsStep)
+    @fake_system.stub_command("defaults read com.apple.screencapture location", "", exit_status: 1)
+
+    refute step.complete?
+  end
+
+  def test_update_reads_current_location_and_writes_to_config
+    step = create_step(Dotfiles::Step::ConfigureScreenshotsStep)
+    @fake_system.stub_command("defaults read com.apple.screencapture location", "~/Documents/Screenshots", exit_status: 0)
+
+    step.update
+    write_op = @fake_system.operations.find { |op| op[0] == :write_file && op[1] == "#{@dotfiles_dir}/config/screenshots.yml" }
+    assert write_op, "Expected write_file operation to #{@dotfiles_dir}/config/screenshots.yml"
+  end
+end


### PR DESCRIPTION
## Summary

Adds a new step that configures macOS to save screenshots to `~/Documents/Inbox`, fixing the issue where screenshots weren't being properly saved to the inbox folder.

## Changes

- **New ConfigureScreenshotsStep**: Sets `com.apple.screencapture location` preference
- **New config file**: `screenshots.yml` with location preference
- **Comprehensive tests**: Full test coverage for the new step
- **Refactored Defaultable mixin** to eliminate code duplication:
  - Extracted `run_defaults_write` method for common write logic
  - Added `type_flag_for` method to automatically detect correct type flags (`-int`, `-float`, `-string`)
  - Updated `parse_defaults_value` to handle string values
  - Updated `DisableAnimationsStep` and `ConfigureTrackpadStep` to use the new methods

## Implementation Details

The step:
- Depends on `CreateStandardFoldersStep` to ensure `~/Documents/Inbox` exists first
- Uses `defaults write com.apple.screencapture location -string ~/Documents/Inbox`
- Restarts `SystemUIServer` to apply changes immediately
- Implements `complete?` to verify the setting is correct
- Implements `update` to sync current settings back to config

## Testing

All tests pass (147 runs, 240 assertions, 0 failures)
- Zero code duplication (flay score: 0/25)
- All complexity checks pass (max: 43.3/50)

Fixes #75

Generated with Claude Code