### PR TITLE
Fix CI: Check both /Applications and ~/Applications for cask apps

### DIFF
--- a/lib/dotfiles/steps/configure_dropbox_step.rb
+++ b/lib/dotfiles/steps/configure_dropbox_step.rb
@@ -20,7 +20,7 @@ class Dotfiles::Step::ConfigureDropboxStep < Dotfiles::Step
   private
 
   def dropbox_installed?
-    @system.dir_exist?("/Applications/Dropbox.app")
+    @system.dir_exist?("/Applications/Dropbox.app") || @system.dir_exist?(File.join(@home, "Applications", "Dropbox.app"))
   end
 
   def dropbox_configured?

--- a/lib/dotfiles/steps/configure_ice_step.rb
+++ b/lib/dotfiles/steps/configure_ice_step.rb
@@ -31,7 +31,7 @@ class Dotfiles::Step::ConfigureIceStep < Dotfiles::Step
   private
 
   def ice_installed?
-    @system.file_exist?("/Applications/Ice.app")
+    @system.file_exist?("/Applications/Ice.app") || @system.file_exist?(File.join(@home, "Applications", "Ice.app"))
   end
 
   def configure_preferences


### PR DESCRIPTION
## Summary

- Fixes CI failure where ConfigureDropboxStep and ConfigureIceStep reported as incomplete
- Updates both steps to check both `/Applications` and `~/Applications` for app installation
- Addresses non-admin installation paths used in CI environments

## Background

In CI environments without admin rights, Homebrew casks are installed to `~/Applications` instead of `/Applications`. The ConfigureDropboxStep and ConfigureIceStep were only checking `/Applications`, causing them to incorrectly report as incomplete when the apps were actually installed to `~/Applications`.

## Test plan

- [x] All existing tests pass locally
- [ ] CI integration tests pass with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)