### PR TITLE
Add hostname check to warn on non-master machines

### DIFF
--- a/bin/dotf
+++ b/bin/dotf
@@ -111,6 +111,42 @@ cmd_run() {
     debug "Run complete"
 }
 
+check_hostname() {
+    cd "$DOTFILES_DIR"
+
+    local hostname_config="$DOTFILES_DIR/config/hostname.yml"
+
+    if [ ! -f "$hostname_config" ]; then
+        debug "No hostname config found, skipping check"
+        return 0
+    fi
+
+    local master_hostname=$(grep "^master_hostname:" "$hostname_config" | sed 's/^master_hostname: *//')
+    local current_hostname=$(hostname)
+
+    debug "Master hostname: $master_hostname"
+    debug "Current hostname: $current_hostname"
+
+    if [ "$master_hostname" != "$current_hostname" ]; then
+        echo ""
+        gum style --border double --border-foreground 208 --padding "1 2" --width 60 \
+            "⚠️  Hostname Mismatch" \
+            "" \
+            "Master hostname: $master_hostname" \
+            "Current hostname: $current_hostname" \
+            "" \
+            "You are not on the master machine."
+        echo ""
+
+        if ! gum confirm "Continue with dotf update anyway?"; then
+            echo "Update cancelled."
+            exit 0
+        fi
+
+        echo ""
+    fi
+}
+
 cmd_update() {
     local git_flags=""
 
@@ -130,6 +166,7 @@ cmd_update() {
         esac
     done
 
+    check_hostname
     update_dotfiles_repo
 
     cd "$DOTFILES_DIR"

--- a/config/hostname.yml
+++ b/config/hostname.yml
@@ -1,0 +1,1 @@
+master_hostname: Nates-MacBook-Pro.local


### PR DESCRIPTION
## Summary

- Adds master hostname designation stored in `config/hostname.yml`
- When running `dotf update` on a non-master machine, displays a warning with `gum` UI
- Requires user confirmation via `gum confirm` to proceed with update
- If declined, exits gracefully without performing update
- Current hostname set as master on initial implementation

## Implementation Details

- Created `config/hostname.yml` with `master_hostname` field
- Added `check_hostname()` function to `bin/dotf` 
- Integrated check into `cmd_update()` before `update_dotfiles_repo()`
- Uses `gum style` for formatted warning box
- Uses `gum confirm` for interactive yes/no prompt

## Test plan

- [x] Verify hostname extraction logic works correctly
- [x] Confirm check is skipped when on master hostname
- [ ] Test warning appears when hostname doesn't match (requires different machine or manual config change)
- [ ] Verify canceling the prompt exits cleanly
- [ ] Verify accepting the prompt continues update normally

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)