### PR TITLE
Add error tracking to step completion checks

### DIFF
--- a/lib/dotfiles/step.rb
+++ b/lib/dotfiles/step.rb
@@ -60,9 +60,10 @@ class Dotfiles
       @ran = false
       @warnings = []
       @notices = []
+      @errors = []
     end
 
-    attr_reader :warnings, :notices, :config
+    attr_reader :warnings, :notices, :config, :errors
 
     def ran?
       @ran
@@ -76,6 +77,10 @@ class Dotfiles
       @notices << {title: title, message: message}
     end
 
+    def add_error(message)
+      @errors << message
+    end
+
     def should_run?
       !complete?
     end
@@ -85,7 +90,7 @@ class Dotfiles
     end
 
     def complete?
-      raise NotImplementedError, "Subclasses must implement #complete?"
+      @errors.clear
     end
 
     # Optional: steps can implement update logic to sync

--- a/lib/dotfiles/steps/check_unmanaged_apps_step.rb
+++ b/lib/dotfiles/steps/check_unmanaged_apps_step.rb
@@ -9,6 +9,7 @@ class Dotfiles::Step::CheckUnmanagedAppsStep < Dotfiles::Step
   end
 
   def complete?
+    super
     true
   end
 

--- a/lib/dotfiles/steps/configure_applications_step.rb
+++ b/lib/dotfiles/steps/configure_applications_step.rb
@@ -8,15 +8,17 @@ class Dotfiles::Step::ConfigureApplicationsStep < Dotfiles::Step
   end
 
   def complete?
+    super
     ghostty_config = app_path("ghostty_config_file")
     aerospace_config = home_path("aerospace_config")
     git_config = home_path("gitconfig")
     hushlogin = home_path("hushlogin")
 
-    files_match?(ghostty_config, dotfiles_source("ghostty_config")) &&
-      files_match?(aerospace_config, dotfiles_source("aerospace_config")) &&
-      files_match?(git_config, dotfiles_source("git_config")) &&
-      files_match?(hushlogin, dotfiles_source("hushlogin"))
+    add_error("Ghostty config not in sync") unless files_match?(ghostty_config, dotfiles_source("ghostty_config"))
+    add_error("Aerospace config not in sync") unless files_match?(aerospace_config, dotfiles_source("aerospace_config"))
+    add_error("Git config not in sync") unless files_match?(git_config, dotfiles_source("git_config"))
+    add_error("Hushlogin not in sync") unless files_match?(hushlogin, dotfiles_source("hushlogin"))
+    @errors.empty?
   end
 
   def update

--- a/lib/dotfiles/steps/configure_dock_step.rb
+++ b/lib/dotfiles/steps/configure_dock_step.rb
@@ -23,12 +23,14 @@ class Dotfiles::Step::ConfigureDockStep < Dotfiles::Step
   end
 
   def complete?
-    defaults_read_equals?(build_read_command("com.apple.dock", "autohide"), "1") &&
-      defaults_read_equals?(build_read_command("com.apple.dock", "orientation"), "left") &&
-      defaults_read_equals?(build_read_command("com.apple.dock", "autohide-delay"), "0") &&
-      defaults_read_equals?(build_read_command("com.apple.dock", "autohide-time-modifier"), "0.4") &&
-      persistent_apps_empty? &&
-      inbox_in_persistent_others?
+    super
+    add_error("Dock autohide not set to true") unless defaults_read_equals?(build_read_command("com.apple.dock", "autohide"), "1")
+    add_error("Dock orientation not set to left") unless defaults_read_equals?(build_read_command("com.apple.dock", "orientation"), "left")
+    add_error("Dock autohide-delay not set to 0") unless defaults_read_equals?(build_read_command("com.apple.dock", "autohide-delay"), "0")
+    add_error("Dock autohide-time-modifier not set to 0.4") unless defaults_read_equals?(build_read_command("com.apple.dock", "autohide-time-modifier"), "0.4")
+    add_error("Dock persistent-apps is not empty") unless persistent_apps_empty?
+    add_error("Inbox folder not in Dock persistent-others") unless inbox_in_persistent_others?
+    @errors.empty?
   end
 
   private

--- a/lib/dotfiles/steps/configure_dropbox_step.rb
+++ b/lib/dotfiles/steps/configure_dropbox_step.rb
@@ -14,7 +14,15 @@ class Dotfiles::Step::ConfigureDropboxStep < Dotfiles::Step
   end
 
   def complete?
-    !dropbox_installed? || dropbox_configured?
+    super
+    return true unless dropbox_installed?
+
+    unless dropbox_configured?
+      add_error("Dropbox is installed but not configured (no Dropbox folder found)")
+      return false
+    end
+
+    true
   end
 
   private

--- a/lib/dotfiles/steps/configure_ice_step.rb
+++ b/lib/dotfiles/steps/configure_ice_step.rb
@@ -19,9 +19,25 @@ class Dotfiles::Step::ConfigureIceStep < Dotfiles::Step
   end
 
   def complete?
+    super
     ice_preferences = app_path("ice_preferences")
-    return false unless ice_preferences && @system.file_exist?(ice_preferences)
-    launch_at_login_configured?
+
+    unless ice_preferences
+      add_error("Ice preferences path not configured")
+      return false
+    end
+
+    unless @system.file_exist?(ice_preferences)
+      add_error("Ice preferences file does not exist at #{ice_preferences}")
+      return false
+    end
+
+    unless launch_at_login_configured?
+      add_error("Ice is not configured to launch at login")
+      return false
+    end
+
+    true
   end
 
   def update

--- a/lib/dotfiles/steps/configure_screenshots_step.rb
+++ b/lib/dotfiles/steps/configure_screenshots_step.rb
@@ -11,9 +11,8 @@ class Dotfiles::Step::ConfigureScreenshotsStep < Dotfiles::Step
   end
 
   def complete?
-    setting_entries.all? do |domain, key, expected_value|
-      defaults_read_equals?(build_read_command(domain, key), expected_value)
-    end
+    super
+    defaults_complete?("Screenshot")
   end
 
   def update

--- a/lib/dotfiles/steps/configure_trackpad_step.rb
+++ b/lib/dotfiles/steps/configure_trackpad_step.rb
@@ -6,9 +6,8 @@ class Dotfiles::Step::ConfigureTrackpadStep < Dotfiles::Step
   end
 
   def complete?
-    setting_entries.all? do |domain, key, expected_value|
-      defaults_read_equals?(build_read_command(domain, key), expected_value.to_s)
-    end
+    super
+    defaults_complete?("Trackpad")
   end
 
   def update

--- a/lib/dotfiles/steps/create_standard_folders_step.rb
+++ b/lib/dotfiles/steps/create_standard_folders_step.rb
@@ -8,10 +8,12 @@ class Dotfiles::Step::CreateStandardFoldersStep < Dotfiles::Step
   end
 
   def complete?
-    standard_folders.all? do |folder|
+    super
+    standard_folders.each do |folder|
       folder_path = @system.path_join(@home, folder)
-      @system.dir_exist?(folder_path)
+      add_error("Standard folder '#{folder}' does not exist at #{folder_path}") unless @system.dir_exist?(folder_path)
     end
+    @errors.empty?
   end
 
   private

--- a/lib/dotfiles/steps/disable_animations_step.rb
+++ b/lib/dotfiles/steps/disable_animations_step.rb
@@ -8,9 +8,8 @@ class Dotfiles::Step::DisableAnimationsStep < Dotfiles::Step
   end
 
   def complete?
-    setting_entries.all? do |domain, key, expected_value|
-      defaults_read_equals?(build_read_command(domain, key), expected_value.to_s)
-    end
+    super
+    defaults_complete?("Animation")
   end
 
   def update

--- a/lib/dotfiles/steps/disable_displays_have_spaces_step.rb
+++ b/lib/dotfiles/steps/disable_displays_have_spaces_step.rb
@@ -7,6 +7,13 @@ class Dotfiles::Step::DisableDisplaysHaveSpacesStep < Dotfiles::Step
   end
 
   def complete?
-    defaults_read_equals?(build_read_command("com.apple.spaces", "spans-displays"), "1")
+    super
+    defaults_complete?("Displays-have-spaces")
+  end
+
+  private
+
+  def setting_entries
+    [["com.apple.spaces", "spans-displays", "1"]]
   end
 end

--- a/lib/dotfiles/steps/install_applications_step.rb
+++ b/lib/dotfiles/steps/install_applications_step.rb
@@ -11,10 +11,12 @@ class Dotfiles::Step::InstallApplicationsStep < Dotfiles::Step
   end
 
   def complete?
-    @config.packages["applications"].all? do |app|
-      @system.dir_exist?(app["path"])
-    end
-  rescue
+    super
+    missing_apps = @config.packages["applications"].reject { |app| @system.dir_exist?(app["path"]) }
+    missing_apps.each { |app| add_error("#{app["name"]} not installed at #{app["path"]}") }
+    missing_apps.empty?
+  rescue => e
+    add_error("Failed to check application installation status: #{e.message}")
     false
   end
 

--- a/lib/dotfiles/steps/install_brew_packages_step.rb
+++ b/lib/dotfiles/steps/install_brew_packages_step.rb
@@ -68,9 +68,20 @@ class Dotfiles::Step::InstallBrewPackagesStep < Dotfiles::Step
   end
 
   def complete?
+    super
     return true if ran?
-    return false unless @system.file_exist?(@brewfile_path)
+
+    unless @system.file_exist?(@brewfile_path)
+      add_error("Brewfile does not exist at #{@brewfile_path}")
+      return false
+    end
+
     raise "packages_already_installed? must be called before complete?" if @packages_installed_status.nil?
+
+    unless @packages_installed_status
+      add_error("Some Homebrew packages are not installed")
+    end
+
     @packages_installed_status
   end
 

--- a/lib/dotfiles/steps/install_homebrew_step.rb
+++ b/lib/dotfiles/steps/install_homebrew_step.rb
@@ -28,6 +28,11 @@ class Dotfiles::Step::InstallHomebrewStep < Dotfiles::Step
   end
 
   def complete?
-    command_exists?("brew") || @skipped_due_to_admin
+    super
+    return true if command_exists?("brew")
+    return true if @skipped_due_to_admin
+
+    add_error("Homebrew is not installed")
+    false
   end
 end

--- a/lib/dotfiles/steps/install_mas_apps_step.rb
+++ b/lib/dotfiles/steps/install_mas_apps_step.rb
@@ -21,10 +21,14 @@ class Dotfiles::Step::InstallMasAppsStep < Dotfiles::Step
   end
 
   def complete?
+    super
     return true if ENV["CI"]
 
-    mas_apps.all? { |app_id, _| app_installed?(app_id) }
-  rescue
+    missing_apps = mas_apps.reject { |app_id, _| app_installed?(app_id) }
+    missing_apps.each { |app_id, app_name| add_error("#{app_name} (#{app_id}) not installed") }
+    missing_apps.empty?
+  rescue => e
+    add_error("Failed to check MAS app installation status: #{e.message}")
     false
   end
 

--- a/lib/dotfiles/steps/set_fish_default_shell_step.rb
+++ b/lib/dotfiles/steps/set_fish_default_shell_step.rb
@@ -25,9 +25,17 @@ class Dotfiles::Step::SetFishDefaultShellStep < Dotfiles::Step
   end
 
   def complete?
+    super
     return true if ci_or_noninteractive?
+
     fish_path, = @system.execute("which fish")
     current_shell, = execute("dscl . -read ~/ UserShell", quiet: true)
-    current_shell.include?(fish_path)
+
+    unless current_shell.include?(fish_path)
+      add_error("Fish is not set as the default shell (current: #{current_shell.strip})")
+      return false
+    end
+
+    true
   end
 end

--- a/lib/dotfiles/steps/set_font_smoothing_step.rb
+++ b/lib/dotfiles/steps/set_font_smoothing_step.rb
@@ -7,14 +7,13 @@ class Dotfiles::Step::SetFontSmoothingStep < Dotfiles::Step
   end
 
   def complete?
-    defaults_read_equals?(build_read_command("NSGlobalDomain", "AppleFontSmoothing", current_host: true), "0")
+    super
+    defaults_complete?("Font smoothing", current_host: true)
   end
 
   private
 
-  def build_read_command(domain, key, current_host: false)
-    domain_flag = domain_flag_for(domain)
-    host_flag = current_host ? "-currentHost " : ""
-    "defaults #{host_flag}read #{domain_flag} #{key}"
+  def setting_entries
+    [["NSGlobalDomain", "AppleFontSmoothing", "0"]]
   end
 end

--- a/lib/dotfiles/steps/setup_ssh_keys_step.rb
+++ b/lib/dotfiles/steps/setup_ssh_keys_step.rb
@@ -48,10 +48,17 @@ class Dotfiles::Step::SetupSSHKeysStep < Dotfiles::Step
   end
 
   def complete?
+    super
     return true if ci_or_noninteractive?
-    return false unless @system.file_exist?(SSH_CONFIG_PATH)
+
+    unless @system.file_exist?(SSH_CONFIG_PATH)
+      add_error("SSH config file does not exist at #{SSH_CONFIG_PATH}")
+      return false
+    end
 
     config_content = @system.read_file(SSH_CONFIG_PATH)
-    config_content.include?("IdentityAgent") && config_content.include?("1password")
+    add_error("SSH config missing IdentityAgent setting") unless config_content.include?("IdentityAgent")
+    add_error("SSH config missing 1Password agent reference") unless config_content.include?("1password")
+    @errors.empty?
   end
 end

--- a/lib/dotfiles/steps/sync_config_directory_step.rb
+++ b/lib/dotfiles/steps/sync_config_directory_step.rb
@@ -9,7 +9,10 @@ class Dotfiles::Step::SyncConfigDirectoryStep < Dotfiles::Step
   end
 
   def complete?
-    config_items.all? { |item| item_in_sync?(item) }
+    super
+    out_of_sync_items = config_items.reject { |item| item_in_sync?(item) }
+    out_of_sync_items.each { |item| add_error("Config item '#{item}' is not in sync") }
+    out_of_sync_items.empty?
   end
 
   def should_run?

--- a/lib/dotfiles/steps/update_homebrew_step.rb
+++ b/lib/dotfiles/steps/update_homebrew_step.rb
@@ -9,6 +9,7 @@ class Dotfiles::Step::UpdateHomebrewStep < Dotfiles::Step
   end
 
   def complete?
+    super
     true
   end
 end

--- a/lib/dotfiles/steps/update_macos_step.rb
+++ b/lib/dotfiles/steps/update_macos_step.rb
@@ -18,11 +18,13 @@ class Dotfiles::Step::UpdateMacOSStep < Dotfiles::Step
   end
 
   def complete?
-    # In CI environments, we don't update macOS so always consider this complete
+    super
     return true if ci_or_noninteractive?
 
     check_background_update_freshness
-    minor_updates_available.empty?
+    updates = minor_updates_available
+    updates.each { |update| add_error("macOS update available: #{update}") }
+    updates.empty?
   end
 
   private

--- a/lib/dotfiles/steps/upgrade_brew_packages_step.rb
+++ b/lib/dotfiles/steps/upgrade_brew_packages_step.rb
@@ -9,6 +9,7 @@ class Dotfiles::Step::UpgradeBrewPackagesStep < Dotfiles::Step
   end
 
   def complete?
+    super
     true
   end
 

--- a/lib/dotfiles/steps/vscode_configuration_step.rb
+++ b/lib/dotfiles/steps/vscode_configuration_step.rb
@@ -19,11 +19,17 @@ class Dotfiles::Step::VSCodeConfigurationStep < Dotfiles::Step
   end
 
   def complete?
+    super
     vscode_settings = app_path("vscode_settings")
     vscode_keybindings = app_path("vscode_keybindings")
 
-    return false unless vscode_settings && vscode_keybindings
-    @system.file_exist?(vscode_settings) && @system.file_exist?(vscode_keybindings)
+    add_error("VS Code settings path not configured") unless vscode_settings
+    add_error("VS Code keybindings path not configured") unless vscode_keybindings
+    return false if @errors.any?
+
+    add_error("VS Code settings file does not exist at #{vscode_settings}") unless @system.file_exist?(vscode_settings)
+    add_error("VS Code keybindings file does not exist at #{vscode_keybindings}") unless @system.file_exist?(vscode_keybindings)
+    @errors.empty?
   end
 
   def update

--- a/test/dotfiles/step_test.rb
+++ b/test/dotfiles/step_test.rb
@@ -6,6 +6,7 @@ class StepTest < Minitest::Test
     end
 
     def complete?
+      super
       true
     end
   end
@@ -19,6 +20,7 @@ class StepTest < Minitest::Test
     end
 
     def complete?
+      super
       true
     end
   end
@@ -32,6 +34,7 @@ class StepTest < Minitest::Test
     end
 
     def complete?
+      super
       true
     end
   end
@@ -41,6 +44,7 @@ class StepTest < Minitest::Test
     end
 
     def complete?
+      super
       true
     end
   end
@@ -50,6 +54,7 @@ class StepTest < Minitest::Test
     end
 
     def complete?
+      super
       true
     end
   end
@@ -107,5 +112,23 @@ class StepTest < Minitest::Test
     step = create_step(TestStepA)
     assert step.complete?
     refute step.should_run?
+  end
+
+  def test_errors_collection
+    step = create_step(TestStepA)
+    step.add_error("First error")
+    step.add_error("Second error")
+
+    assert_equal 2, step.errors.length
+    assert_equal "First error", step.errors[0]
+    assert_equal "Second error", step.errors[1]
+  end
+
+  def test_errors_cleared_on_complete_check
+    step = create_step(TestStepA)
+    step.add_error("Stale error")
+    step.complete?
+
+    assert_empty step.errors
   end
 end


### PR DESCRIPTION
## Summary

- Added error tracking to all step completion checks
- Steps now populate `@errors` array with detailed explanations when `complete?` returns false
- Errors are displayed to users in formatted output grouped by step
- Refactored `Dotfiles::Runner#collect_step_results` to reduce complexity (43.3 → 39.0)

## Implementation Details

### Step Error Tracking
- Added `@errors` instance variable and `errors` reader to base `Dotfiles::Step` class
- Added `add_error(message)` helper method for steps to report issues
- Base class `complete?` method clears `@errors` before each check via `super` pattern

### Code Quality Improvements
- Extracted `defaults_complete?(setting_type_name)` helper in `Defaultable` module
- Eliminated code duplication across 23+ step files (flay score: 0)
- Standardized single-setting steps to use `setting_entries` array pattern
- Added `current_host` parameter support to `build_read_command`

### Runner Enhancements
- Extracted `collect_single_step_result` method to reduce complexity
- Added `display_errors` method to show formatted error messages
- Errors grouped by step and displayed with styled borders using `gum`

## Test Plan

- All 149 tests passing with 245 assertions
- No code duplication detected
- Complexity reduced as measured by flog

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>