### PR TITLE
Make gc-ai condense prompt explicit about halving description length

### DIFF
--- a/files/config/fish/functions/gc-ai.fish
+++ b/files/config/fish/functions/gc-ai.fish
@@ -168,7 +168,7 @@ $claude_context"
                 echo "Condensing message..."
                 set current_message (cat $display_file)
                 set condensed_file (mktemp)
-                echo "Take this commit message and make it more concise while retaining the what and the why:
+                echo "Take this commit message and condense it. Keep the first line (summary) exactly as-is. Make the description (body) half as long while retaining the what and the why:
 
 $current_message" | llm > $condensed_file
                 rm $display_file


### PR DESCRIPTION
## Summary
Makes the condense feature in gc-ai explicitly tell the LLM to:
- Keep the summary line (first line) exactly as-is
- Make the description (body) half as long

Fixes #28

## Test plan
- Test gc-ai with a commit that has a long description
- Use the "Condense" option and verify the summary stays the same and the description is approximately half as long