### PR TITLE
Add thefuck for command correction

### DIFF
--- a/config/packages.yml
+++ b/config/packages.yml
@@ -6,11 +6,12 @@ brew:
     - fontconfig
     - gh
     - libyaml
+    - llm
     - mas
     - mise
-    - llm
     - rust
     - starship
+    - thefuck
     - zoxide
 
   casks:

--- a/files/config/fish/functions/fuck.fish
+++ b/files/config/fish/functions/fuck.fish
@@ -1,0 +1,9 @@
+function fuck -d "Correct your previous console command"
+  set -l fucked_up_command $history[1]
+  env TF_SHELL=fish TF_ALIAS=fuck PYTHONIOENCODING=utf-8 thefuck $fucked_up_command THEFUCK_ARGUMENT_PLACEHOLDER $argv | read -l unfucked_command
+  if [ "$unfucked_command" != "" ]
+    eval $unfucked_command
+    builtin history delete --exact --case-sensitive -- $fucked_up_command
+    builtin history merge
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `thefuck` package for automatic command correction
- Uses autoloaded Fish function to avoid shell startup delay
- Type "fuck" after a failed command to see corrections

## Changes
- Added `thefuck` to homebrew packages in `config/packages.yml`
- Created `files/config/fish/functions/fuck.fish` with autoloaded function

## Implementation Details

Instead of adding `thefuck --alias | source` to `config.fish` (which slows down shell startup), this uses Fish's autoload function feature. The function is only loaded when first invoked, keeping shell startup fast.

## Usage

```fish
$ git push
fatal: The current branch has no upstream branch.
$ fuck
git push --set-upstream origin main [enter/↑/↓/ctrl+c]
```

## Test plan
- [x] All existing tests pass (147 runs, 253 assertions)
- [x] Package added to packages.yml in alphabetical order
- [x] Function file created with correct thefuck alias output
- [x] Lint checks pass (standardrb, flog, flay)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)