### PR TITLE
Further simplify dotfiles by removing unused path helper methods

### DIFF
--- a/config/paths.yml
+++ b/config/paths.yml
@@ -1,5 +1,2 @@
 dotfiles_repo: https://github.com/nateberkopec/dotfiles.git
 # home: /Users/yourusername  # Override default home directory (defaults to ENV["HOME"])
-
-home_paths:
-  zprofile: ~/.zprofile

--- a/lib/dotfiles/step.rb
+++ b/lib/dotfiles/step.rb
@@ -158,16 +158,6 @@ class Dotfiles
       output == normalize_defaults_value(expected_value)
     end
 
-    def home_path(key)
-      path = @config.paths.dig("home_paths", key.to_s)
-      path ? expand_path_with_home(path) : nil
-    end
-
-    def app_path(key)
-      path = @config.paths.dig("application_paths", key.to_s)
-      path ? expand_path_with_home(path) : nil
-    end
-
     def expand_path_with_home(path)
       expanded = path.sub(/^~/, @home)
       File.expand_path(expanded)
@@ -177,11 +167,6 @@ class Dotfiles
       return path unless path.is_a?(String)
       return path unless @home && path.start_with?(@home)
       path.sub(@home, "~")
-    end
-
-    def dotfiles_source(key)
-      source = @config.paths.dig("dotfiles_sources", key.to_s)
-      source ? File.join(@dotfiles_dir, source) : nil
     end
 
     def normalize_defaults_value(value)

--- a/lib/dotfiles/steps/install_homebrew_step.rb
+++ b/lib/dotfiles/steps/install_homebrew_step.rb
@@ -20,7 +20,7 @@ class Dotfiles::Step::InstallHomebrewStep < Dotfiles::Step
     debug "Installing Homebrew..."
     execute('/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
 
-    zprofile_path = home_path("zprofile")
+    zprofile_path = File.join(@home, ".zprofile")
     existing_content = @system.file_exist?(zprofile_path) ? @system.read_file(zprofile_path) : ""
     @system.write_file(zprofile_path, existing_content + 'eval "$(/opt/homebrew/bin/brew shellenv)"' + "\n")
 

--- a/test/dotfiles/config_test.rb
+++ b/test/dotfiles/config_test.rb
@@ -18,8 +18,8 @@ class ConfigTest < Minitest::Test
     config = Dotfiles::Config.new(@fixtures_dir)
     paths = config.paths
 
-    assert_equal "~/.config/fish", paths["home_paths"]["fish_config_dir"]
-    assert_equal "files/fish/config.fish", paths["dotfiles_sources"]["fish_config"]
+    # Paths config is now minimal, just verify it loads
+    assert_kind_of Hash, paths
   end
 
   def test_dotfiles_repo_from_config

--- a/test/fixtures/config/paths.yml
+++ b/test/fixtures/config/paths.yml
@@ -1,12 +1,1 @@
 dotfiles_repo: https://github.com/test/dotfiles.git
-
-home_paths:
-  fish_config_dir: ~/.config/fish
-  fish_config_file: ~/.config/fish/config.fish
-
-application_paths:
-  vscode_user_dir: ~/Library/Application Support/Code/User
-
-dotfiles_sources:
-  fish_config: files/fish/config.fish
-  vscode_settings: files/vscode/settings.json

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,26 +35,6 @@ class Minitest::Test
     step_class.new(**defaults.merge(overrides))
   end
 
-  def stub_default_paths(step)
-    step.config.paths = {
-      "application_paths" => {
-        "ghostty_config_dir" => "#{@home}/Library/Application Support/com.mitchellh.ghostty",
-        "ghostty_config_file" => "#{@home}/Library/Application Support/com.mitchellh.ghostty/config"
-      },
-      "home_paths" => {
-        "aerospace_config" => "#{@home}/.aerospace.toml",
-        "gitconfig" => "#{@home}/.gitconfig",
-        "hushlogin" => "#{@home}/.hushlogin"
-      },
-      "dotfiles_sources" => {
-        "ghostty_config" => "files/ghostty/config",
-        "aerospace_config" => "files/aerospace/.aerospace.toml",
-        "git_config" => "files/git/.gitconfig",
-        "hushlogin" => "files/.hushlogin"
-      }
-    }
-  end
-
   def with_ci
     ENV["CI"] = "true"
     yield


### PR DESCRIPTION
## Summary
Removes obsolete infrastructure that was replaced by SyncHomeDirectoryStep in #92:
- Removed `app_path()`, `home_path()`, and `dotfiles_source()` helper methods
- Removed `home_paths`, `application_paths`, and `dotfiles_sources` sections from paths.yml
- Hardcoded `.zprofile` path in InstallHomebrewStep instead of using config lookup
- Simplified test fixtures to match minimal paths.yml structure

## Impact
- Reduces complexity by 51 lines of code
- Simplifies paths.yml to just contain dotfiles_repo URL
- Makes the codebase more straightforward - file paths are now explicit rather than configured

## Testing
All tests pass (124 runs, 217 assertions, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)