### PR TITLE
Set mise minimum release age

### DIFF
--- a/files/home/.config/mise/config.toml
+++ b/files/home/.config/mise/config.toml
@@ -39,6 +39,7 @@ experimental = true
 github.credential_command = "gh auth token"
 ruby.compile = false
 fetch_remote_versions_cache = "7d"
+minimum_release_age = "3d"
 http_timeout = "5s"
 fetch_remote_versions_timeout = "5s"
 


### PR DESCRIPTION
## Summary
- Set systemwide mise minimum_release_age to 3d

## Testing
- python3 TOML parse/assertion
- pre-commit hook: standard, complexity, large-files, secrets, dead-code, flog, flay, skills, test