### PR TITLE
Reinstall npm-backed mise tools with aube

### DIFF
--- a/lib/dotfiles/migrations/202605310002_reinstall_npm_mise_tools_with_aube.rb
+++ b/lib/dotfiles/migrations/202605310002_reinstall_npm_mise_tools_with_aube.rb
@@ -1,0 +1,46 @@
+class Dotfiles::Migration::ReinstallNpmMiseToolsWithAube < Dotfiles::Migration
+  VERSION = 202605310002
+
+  MISE_TOOLS = [
+    "npm:@openai/codex",
+    "npm:@earendil-works/pi-coding-agent",
+    "npm:@tobilu/qmd",
+    "heroku"
+  ].freeze
+
+  def up
+    return unless command_exists?("mise")
+
+    install_aube
+    MISE_TOOLS.each { |tool| reinstall_tool(tool) }
+  end
+
+  def down
+    raise NotImplementedError, "This migration reinstalls tools and cannot be safely reversed."
+  end
+
+  private
+
+  def install_aube
+    execute(mise_command("install", "--yes", "aube"))
+  end
+
+  def reinstall_tool(tool)
+    return unless tool_installed?(tool)
+
+    execute(mise_command("uninstall", "--yes", tool))
+    execute(aube_mise_command("install", "--yes", tool))
+  end
+
+  def tool_installed?(tool)
+    command_succeeds?(mise_command("where", tool))
+  end
+
+  def aube_mise_command(*args)
+    env_command({"MISE_NPM_PACKAGE_MANAGER" => "aube"}, *mise_command(*args))
+  end
+
+  def mise_command(*args)
+    command("mise", "--cd", @home, *args)
+  end
+end


### PR DESCRIPTION
Phase 3 for #349. Stacked on #396.\n\n- Add a dotf migration for existing machines\n- Reinstalls currently-installed npm-backed mise tools with MISE_NPM_PACKAGE_MANAGER=aube\n- Leaves absent tools alone; the normal install step will install them later from managed config\n\nTests: bundle exec rake test; bundle exec standardrb lib/dotfiles/migrations/202605310002_reinstall_npm_mise_tools_with_aube.rb