### PR TITLE
Enable aube paranoid mode

### DIFF
--- a/files/home/.config/aube/config.toml
+++ b/files/home/.config/aube/config.toml
@@ -1,0 +1,2 @@
+# Managed by dotfiles. Harden npm installs that flow through aube.
+paranoid = true


### PR DESCRIPTION
Turns on aube's strict security bundle with user-scope config.\n\n- Adds managed ~/.config/aube/config.toml\n- Sets paranoid = true, which enables jailed builds, strict release-age/integrity/build handling, and required advisory checks\n\nReference: https://aube.en.dev/security.html\n\nTests: bundle exec rake test