### PR TITLE
Fix Pi OpenRouter env var reference

### DIFF
--- a/files/home/.pi/agent/extensions/openrouter_guardrail/provider.ts
+++ b/files/home/.pi/agent/extensions/openrouter_guardrail/provider.ts
@@ -15,7 +15,7 @@ export function hideOpenRouter(pi: ExtensionAPI) {
     name: "OpenRouter (guardrail unavailable)",
     baseUrl: OPENROUTER_BASE_URL,
     api: "openai-completions",
-    apiKey: "OPENROUTER_API_KEY",
+    apiKey: "$OPENROUTER_API_KEY",
     models: [unavailableModel()],
   });
 }


### PR DESCRIPTION
## Summary
- pass OpenRouter provider fallback API key as an explicit env-var reference

## Test
- pre-commit lint hooks
- `bundle exec rake test`