### PR TITLE
Route running_container? through adapter methods

### DIFF
--- a/lib/dotfiles/system_adapter.rb
+++ b/lib/dotfiles/system_adapter.rb
@@ -25,8 +25,8 @@ class Dotfiles
     end
 
     def running_container?
-      File.exist?("/.dockerenv") ||
-        (File.exist?("/proc/1/cgroup") && File.read("/proc/1/cgroup").include?("docker"))
+      file_exist?("/.dockerenv") ||
+        (file_exist?("/proc/1/cgroup") && read_file("/proc/1/cgroup").include?("docker"))
     end
 
     def file_exist?(path)


### PR DESCRIPTION
## Why

`SystemAdapter#running_container?` called `File.exist?` and `File.read` directly, bypassing the adapter's own `file_exist?`/`read_file` methods. This is the kind of direct-filesystem access the custom `standardrb` cops discourage elsewhere, and it makes the method inconsistent with the rest of the adapter.

## What

Route through `file_exist?` and `read_file` so the adapter is internally consistent and `running_container?` benefits from any future overrides.

## Tests

Existing tests stub the underlying `File.exist?`/`File.read`, which `file_exist?`/`read_file` delegate to, so they stay green: 419 runs, 0 failures.