### PR TITLE
Simplify find_fish_path memoization

### DIFF
--- a/lib/dotfiles/step.rb
+++ b/lib/dotfiles/step.rb
@@ -241,8 +241,15 @@ class Dotfiles
     end
 
     def find_fish_path
-      return @fish_path if defined?(@fish_path) && !@fish_path.to_s.empty?
+      return @fish_path if @fish_path_resolved
 
+      path = resolve_fish_path
+      @fish_path = path
+      @fish_path_resolved = !path.to_s.empty?
+      path
+    end
+
+    def resolve_fish_path
       mise_fish = @system.glob(File.join(@home, ".local", "share", "mise", "installs", "aqua-fish-shell-fish-shell", "*", "{fish,fish.pkg/Payload/usr/local/bin/fish}")).max
       candidates = [
         mise_fish,
@@ -253,10 +260,10 @@ class Dotfiles
         "/home/linuxbrew/.linuxbrew/bin/fish"
       ]
       candidate = candidates.compact.find { |path| @system.file_exist?(path) }
-      return @fish_path = candidate if candidate
+      return candidate if candidate
 
       output, status = @system.execute(shell_script('command -v -- "$1" 2>/dev/null', "fish"))
-      @fish_path = (status == 0) ? output.strip : ""
+      (status == 0) ? output.strip : ""
     end
 
     def temp_path(label)


### PR DESCRIPTION
## Why

`Step#find_fish_path` used `defined?(@fish_path) && !@fish_path.to_s.empty?` to guard memoization, which conflates "not computed" with "computed but empty". The empty-but-computed case is intentional: an empty result must **not** be memoized so a later call rechecks after fish becomes available (see `test_rechecks_fish_path_after_initial_miss`).

## What

- Replace the string guard with an explicit `@fish_path_resolved` flag that is only set when a non-empty path is found.
- Extract the lookup logic into `resolve_fish_path`.

## Tests

419 runs, 0 failures; standardrb/flog/flay/dead-code clean.