### PR TITLE
Lock dotf run/upgrade/migrate against concurrent execution

### DIFF
--- a/bin/dotf
+++ b/bin/dotf
@@ -125,7 +125,39 @@ is_debian() {
     [ "${DOTF_FORCE_DEBIAN:-false}" = "true" ] || [ -f /etc/debian_version ]
 }
 
+DOTF_LOCK_DIR="${DOTF_LOCK_DIR:-$HOME/.dotfiles.lock}"
+
+acquire_dotf_lock() {
+    if mkdir "$DOTF_LOCK_DIR" 2>/dev/null; then
+        echo "$$" > "$DOTF_LOCK_DIR/pid"
+        trap release_dotf_lock EXIT
+        return 0
+    fi
+
+    local existing_pid
+    existing_pid="$(cat "$DOTF_LOCK_DIR/pid" 2>/dev/null)" || true
+    if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+        echo "Error: another dotf instance is already running (PID $existing_pid, lock: $DOTF_LOCK_DIR). If stale, remove $DOTF_LOCK_DIR." >&2
+        exit 1
+    fi
+
+    rm -rf "$DOTF_LOCK_DIR" 2>/dev/null || true
+    if mkdir "$DOTF_LOCK_DIR" 2>/dev/null; then
+        echo "$$" > "$DOTF_LOCK_DIR/pid"
+        trap release_dotf_lock EXIT
+        return 0
+    fi
+
+    echo "Error: could not acquire dotf lock at $DOTF_LOCK_DIR" >&2
+    exit 1
+}
+
+release_dotf_lock() {
+    rm -rf "$DOTF_LOCK_DIR" 2>/dev/null || true
+}
+
 cmd_run() {
+    acquire_dotf_lock
     init_logging
     debug "Starting dotf run command"
     "$SCRIPT_DIR/bootstrap"
@@ -140,6 +172,7 @@ cmd_run() {
 }
 
 cmd_upgrade() {
+    acquire_dotf_lock
     init_logging
     debug "Starting dotf upgrade command"
     is_debian || ensure_homebrew_env
@@ -202,6 +235,7 @@ cmd_upgrade() {
 }
 
 cmd_migrate() {
+    acquire_dotf_lock
     init_logging
     debug "Starting dotf migrate command"
     ensure_homebrew_env

--- a/test/dotfiles/dotf_cli_test.rb
+++ b/test/dotfiles/dotf_cli_test.rb
@@ -50,6 +50,39 @@ class DotfCliTest < Minitest::Test
     )
   end
 
+  def test_acquire_dotf_lock_blocks_second_live_holder
+    with_dotf_script do |tmpdir, script_path, _logs_dir|
+      lock_dir = File.join(tmpdir, "dotf.lock")
+      escaped_script = Shellwords.escape(script_path)
+      escaped_lock = Shellwords.escape(lock_dir)
+      holder_cmd = "source #{escaped_script}; export DOTF_LOCK_DIR=#{escaped_lock}; acquire_dotf_lock; sleep 2"
+      holder = IO.popen(["bash", "-c", holder_cmd])
+      begin
+        sleep 0.5
+        second = system({"DOTF_LOCK_DIR" => lock_dir}, "bash", "-c", "source #{escaped_script}; acquire_dotf_lock", out: File::NULL, err: File::NULL)
+        refute second
+      ensure
+        begin
+          Process.kill("TERM", holder.pid)
+        rescue
+          nil
+        end
+        holder.wait
+      end
+    end
+  end
+
+  def test_acquire_dotf_lock_recovers_stale_lock
+    with_dotf_script do |tmpdir, script_path, _logs_dir|
+      lock_dir = File.join(tmpdir, "dotf.lock")
+      FileUtils.mkdir_p(lock_dir)
+      File.write(File.join(lock_dir, "pid"), "999999")
+      escaped_script = Shellwords.escape(script_path)
+
+      assert system({"DOTF_LOCK_DIR" => lock_dir}, "bash", "-c", "source #{escaped_script}; acquire_dotf_lock", out: File::NULL)
+    end
+  end
+
   def test_run_runs_migrations_before_setup_steps
     with_dotf_script do |tmpdir, script_path, _logs_dir|
       log_path = File.join(tmpdir, "run-commands.log")
@@ -72,7 +105,8 @@ class DotfCliTest < Minitest::Test
       FileUtils.mkdir_p(bin_dir)
       stubs.each { |command| write_command_stub(bin_dir, command) }
 
-      with_env(env.merge("DOTF_UPGRADE_LOG" => log_path, "PATH" => "#{bin_dir}:/usr/bin:/bin")) do
+      lock_dir = File.join(tmpdir, "dotf.lock")
+      with_env(env.merge("DOTF_UPGRADE_LOG" => log_path, "DOTF_LOCK_DIR" => lock_dir, "PATH" => "#{bin_dir}:/usr/bin:/bin")) do
         clean_homebrew_env = {"HOMEBREW_AUTO_UPDATE_SECS" => nil, "HOMEBREW_NO_AUTO_UPDATE" => nil}
         assert system(clean_homebrew_env, "bash", script_path, "upgrade", out: File::NULL)
       end
@@ -110,6 +144,7 @@ class DotfCliTest < Minitest::Test
     escaped_log = Shellwords.escape(log_path)
     <<~BASH
       source #{escaped_script}
+      export DOTF_LOCK_DIR=#{Shellwords.escape(File.join(File.dirname(escaped_log), "dotf.lock"))}
       mise() { printf 'mise %s\\n' "$*" >> #{escaped_log}; }
       ruby() { printf 'ruby %s\\n' "$*" >> #{escaped_log}; }
       cmd_run


### PR DESCRIPTION
## Why

`dotf run`/`upgrade`/`migrate` mutate shared state (Homebrew, mise, home files). Two concurrent invocations — e.g. a user and an agent running in YOLO mode — will stomp each other. This reinforces the agent-safety goals in the README.

## What

- Acquire a lock at the start of each of `cmd_run`, `cmd_upgrade`, `cmd_migrate`.
- The lock lives at `\$HOME/.dotfiles.lock` (override via `DOTF_LOCK_DIR`) **in the home folder, not the checkout**, so a temporary checkout in `/tmp` is still guarded against the real `~/.dotfiles` run.
- macOS does not ship `flock`, so this uses a portable `mkdir`-atomic lock directory with a pid file and stale-lock recovery (works on macOS and Debian).
- Released via an `EXIT` trap.

## Tests

- Existing CLI tests updated to point `DOTF_LOCK_DIR` at a temp dir.
- New `test_acquire_dotf_lock_blocks_second_live_holder`: a background holder blocks a second acquisition.
- New `test_acquire_dotf_lock_recovers_stale_lock`: a lock dir with a dead pid is reclaimed.

421 runs, 0 failures; standardrb/secrets/human-only clean.