### PR TITLE
Surface mise updates-available in dotf upgrade

### DIFF
--- a/bin/dotf
+++ b/bin/dotf
@@ -94,6 +94,30 @@ warn() {
     fi
 }
 
+report_mise_updates() {
+    announce "Checking for mise updates"
+    (
+        unset BUNDLE_GEMFILE BUNDLE_BIN_PATH RUBYOPT GEM_HOME GEM_PATH 2>/dev/null || true
+        mise outdated --json 2>/dev/null | ruby -rjson -e '
+            begin
+              tools = JSON.parse(STDIN.read)
+            rescue JSON::ParserError
+              exit 0
+            end
+            semver = ->(v) { v.to_s.match?(/^v?\d+(?:\.\d+)*(?:[-+][0-9A-Za-z.-]+)?$/) }
+            actionable = tools.select do |_name, t|
+              semver.call(t["requested"]) && semver.call(t["current"]) && semver.call(t["latest"]) && t["current"] != t["latest"]
+            end
+            if actionable.empty?
+              puts "mise tools are up to date"
+            else
+              puts "#{actionable.size} tool(s) have updates available:"
+              actionable.each { |name, t| puts "  #{name}: #{t["current"]} -> #{t["latest"]}" }
+            end
+        '
+    )
+}
+
 ensure_homebrew_env() {
     if [ -x "$HOME/.homebrew/bin/brew" ]; then
         eval "$("$HOME/.homebrew/bin/brew" shellenv bash)"
@@ -158,6 +182,7 @@ cmd_upgrade() {
     announce "Refreshing mise metadata"
     mise cache clear --yes
     mise plugins update
+    report_mise_updates
 
     announce "Checking for mise updates older than $PACKAGE_UPGRADE_DELAY"
     mise up --dry-run --before "$PACKAGE_UPGRADE_DELAY" --yes

--- a/test/dotfiles/dotf_cli_test.rb
+++ b/test/dotfiles/dotf_cli_test.rb
@@ -26,6 +26,7 @@ class DotfCliTest < Minitest::Test
       env: {"DOTF_FORCE_NON_DEBIAN" => "true"},
       expected: [
         "brew shellenv bash", "mise activate bash", "mise cache clear --yes", "mise plugins update",
+        "mise outdated --json",
         "mise up --dry-run --before 3d --yes", "mise up --before 3d --yes",
         "mise install --before 3d --yes", "pi update --extensions",
         "mise prune --yes", "mise cache prune --yes", "MISE_EXPERIMENTAL=1 mise system install --help",
@@ -43,6 +44,7 @@ class DotfCliTest < Minitest::Test
       env: {"DOTF_FORCE_DEBIAN" => "true", "DOTF_SKIP_SUDO" => "true"},
       expected: [
         "mise activate bash", "mise cache clear --yes", "mise plugins update",
+        "mise outdated --json",
         "mise up --dry-run --before 3d --yes", "mise up --before 3d --yes",
         "mise install --before 3d --yes", "mise prune --yes", "mise cache prune --yes",
         "MISE_EXPERIMENTAL=1 mise system install --help", "MISE_EXPERIMENTAL=1 mise system install --yes --update"


### PR DESCRIPTION
## Why

`dotf upgrade` ran `mise up --dry-run --before 3d` but never showed which tools had updates available, so the "updates available" signal lived only in `CheckMiseUpdatesStep` (a `dotf run` step). The two worlds never met.

## What

- Add `report_mise_updates` to `cmd_upgrade`, run after `mise plugins update`.
- Runs `mise outdated --json` and prints the actionable tools (`current -> latest`), reusing the same semver filter as `CheckMiseUpdatesStep` (excludes tools pinned to non-semver requested/current/latest).
- The `ruby` invocation clears bundler env vars (`BUNDLE_GEMFILE`/`RUBYOPT`/etc.) so it uses stdlib `json` on whichever ruby is on PATH — system Ruby in tests, mise Ruby in production. Without this, the vendored `json` 2.18 gem leaks onto system Ruby 2.6 under `bundle exec` and fails to parse.

## Tests

Updated the two upgrade command-sequence tests to expect `mise outdated --json` after `mise plugins update`. 419 runs, 0 failures; standardrb/secrets/human-only clean.