### PR TITLE
Share bash helpers between bin/dotf and bin/bootstrap

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -2,6 +2,10 @@
 
 set -e
 
+BOOTSTRAP_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/dotf-common.sh
+source "$BOOTSTRAP_DIR/lib/dotf-common.sh"
+
 is_macos() {
     [ "$(uname -s)" = "Darwin" ]
 }
@@ -12,12 +16,7 @@ is_linux() {
 
 debug() {
     if [ "${DEBUG:-false}" = "true" ]; then
-        # Use gdate if available (GNU coreutils on macOS), otherwise use standard date without milliseconds
-        if command -v gdate &> /dev/null; then
-            timestamp=$(gdate '+%H:%M:%S.%3N')
-        else
-            timestamp=$(date '+%H:%M:%S')
-        fi
+        timestamp=$(dotf_date '%H:%M:%S.%3N' '%H:%M:%S')
         echo "[$timestamp] $1"
     fi
 }
@@ -27,14 +26,6 @@ brew_quiet() {
         HOMEBREW_NO_AUTO_UPDATE=1 brew "$@"
     else
         HOMEBREW_NO_AUTO_UPDATE=1 brew "$@" >/dev/null 2>&1
-    fi
-}
-
-stdout_quiet_unless_debug() {
-    if [ "${DEBUG:-false}" = "true" ]; then
-        "$@"
-    else
-        "$@" >/dev/null
     fi
 }
 

--- a/bin/dotf
+++ b/bin/dotf
@@ -15,6 +15,8 @@ done
 SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE_PATH")" && pwd)"
 DOTFILES_DIR="$(dirname "$SCRIPT_DIR")"
 export DOTFILES_DIR
+# shellcheck source=lib/dotf-common.sh
+source "$SCRIPT_DIR/lib/dotf-common.sh"
 LOGS_DIR="$DOTFILES_DIR/logs"
 LOG_RETENTION=30
 PACKAGE_UPGRADE_DELAY="${DOTF_PACKAGE_UPGRADE_DELAY:-3d}"
@@ -50,23 +52,14 @@ init_logging() {
     mkdir -p "$LOGS_DIR"
     rotate_logs $((LOG_RETENTION - 1))
     # Generate timestamp for log filename
-    if command -v gdate &> /dev/null; then
-        LOG_TIMESTAMP=$(gdate '+%Y-%m-%d_%H-%M-%S')
-    else
-        LOG_TIMESTAMP=$(date '+%Y-%m-%d_%H-%M-%S')
-    fi
+    LOG_TIMESTAMP=$(dotf_date '%Y-%m-%d_%H-%M-%S')
     LOG_FILE="$LOGS_DIR/dotf_${LOG_TIMESTAMP}.log"
     export LOG_FILE
     : > "$LOG_FILE"
 }
 
 debug() {
-    # Use gdate if available (GNU coreutils on macOS), otherwise use standard date without milliseconds
-    if command -v gdate &> /dev/null; then
-        timestamp=$(gdate '+%H:%M:%S.%3N')
-    else
-        timestamp=$(date '+%H:%M:%S')
-    fi
+    timestamp=$(dotf_date '%H:%M:%S.%3N' '%H:%M:%S')
     local message="[$timestamp] $1"
 
     # Always write to log file

--- a/bin/lib/dotf-common.sh
+++ b/bin/lib/dotf-common.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Shared helpers for bin/dotf and bin/bootstrap.
+#
+# Source this file from either script. It must not depend on any variables
+# defined by the sourcing script, so it can be loaded early.
+
+# Print a timestamp using gdate (GNU coreutils) when available, otherwise
+# fall back to BSD date. The first argument is the GNU format string; the
+# optional second argument is the POSIX fallback format used when gdate is
+# absent (defaults to the GNU format). This is the single place that decides
+# whether to use gdate, so the macOS/BSD fallback lives in one spot.
+dotf_date() {
+    local gnu_format="$1"
+    local posix_format="${2:-$gnu_format}"
+    if command -v gdate &> /dev/null; then
+        gdate "+$gnu_format"
+    else
+        date "+$posix_format"
+    fi
+}
+
+# Run a command quietly unless DEBUG=true.
+stdout_quiet_unless_debug() {
+    if [ "${DEBUG:-false}" = "true" ]; then
+        "$@"
+    else
+        "$@" >/dev/null
+    fi
+}

--- a/test/support/dotf_script_helper.rb
+++ b/test/support/dotf_script_helper.rb
@@ -13,6 +13,7 @@ module DotfScriptHelper
 
       script_path = File.join(bin_dir, "dotf")
       FileUtils.cp(File.expand_path("../../bin/dotf", __dir__), script_path)
+      FileUtils.cp_r(File.expand_path("../../bin/lib", __dir__), File.join(tmpdir, "bin"))
 
       yield tmpdir, script_path, logs_dir
     end


### PR DESCRIPTION
## Why

The gdate-vs-date timestamp fallback was duplicated in three places (`bin/bootstrap` debug, `bin/dotf` debug, `bin/dotf` init_logging), and `stdout_quiet_unless_debug` lived only in `bin/bootstrap`. One fix to the fallback meant three edits.

## What

- New `bin/lib/dotf-common.sh` with two helpers:
  - `dotf_date` — centralizes gdate detection. Takes a GNU format and an optional POSIX fallback format (defaults to the GNU format), so the macOS/BSD fallback lives in one spot.
  - `stdout_quiet_unless_debug` — moved out of `bin/bootstrap` so both scripts can use it.
- `bin/bootstrap` resolves its own dir and sources the lib; its `debug()` uses `dotf_date`.
- `bin/dotf` sources the lib; `init_logging` and `debug()` use `dotf_date`.

## Notes

- The two `debug()` functions still differ (bootstrap only echoes on `DEBUG`; dotf always writes to the log file), so they are **not** merged — only the timestamp primitive is shared.
- `ensure_homebrew_env` and `configure_mise_ruby_precompiled` were each in only one file (not actually duplicated), so moving them would change behavior; left in place.

## Tests

`with_dotf_script` now copies `bin/lib` alongside `bin/dotf`. 419 runs, 0 failures; all lints clean (standardrb/flog/flay/dead-code/secrets/human-only/large-files).