### PR TITLE
Inject a shared Config into steps and migrations

### DIFF
--- a/lib/dotfiles/migration.rb
+++ b/lib/dotfiles/migration.rb
@@ -34,9 +34,9 @@ class Dotfiles
       @debian_only || false
     end
 
-    def initialize(debug:, dotfiles_repo:, dotfiles_dir:, home:, system: SystemAdapter.new)
+    def initialize(debug:, dotfiles_repo:, dotfiles_dir:, home:, system: SystemAdapter.new, config: nil)
       @debug, @dotfiles_repo, @dotfiles_dir, @home, @system = debug, dotfiles_repo, dotfiles_dir, home, system
-      @config = Config.new(dotfiles_dir, system: system)
+      @config = config || Config.new(dotfiles_dir, system: system)
     end
 
     def allowed_on_platform?

--- a/lib/dotfiles/migration_runner.rb
+++ b/lib/dotfiles/migration_runner.rb
@@ -50,7 +50,8 @@ class Dotfiles
         dotfiles_repo: @config.dotfiles_repo,
         dotfiles_dir: @dotfiles_dir,
         home: @home,
-        system: @system
+        system: @system,
+        config: @config
       }
     end
 

--- a/lib/dotfiles/runner.rb
+++ b/lib/dotfiles/runner.rb
@@ -32,7 +32,8 @@ class Dotfiles
         debug: @debug,
         dotfiles_repo: @config.dotfiles_repo,
         dotfiles_dir: @config.dotfiles_dir,
-        home: @config.home
+        home: @config.home,
+        config: @config
       }
     end
 

--- a/lib/dotfiles/step.rb
+++ b/lib/dotfiles/step.rb
@@ -91,9 +91,9 @@ class Dotfiles
       context[:result] << step
     end
 
-    def initialize(debug:, dotfiles_repo:, dotfiles_dir:, home:, system: SystemAdapter.new)
+    def initialize(debug:, dotfiles_repo:, dotfiles_dir:, home:, system: SystemAdapter.new, config: nil)
       @debug, @dotfiles_repo, @dotfiles_dir, @home, @system = debug, dotfiles_repo, dotfiles_dir, home, system
-      @config = Config.new(dotfiles_dir, system: system)
+      @config = config || Config.new(dotfiles_dir, system: system)
       reset_state
     end
 

--- a/test/dotfiles/runner_test.rb
+++ b/test/dotfiles/runner_test.rb
@@ -44,6 +44,13 @@ class RunnerTest < Minitest::Test
     assert_equal 0, step.should_run_calls
   end
 
+  def test_build_step_params_shares_runner_config
+    runner = Dotfiles::Runner.new
+    params = runner.send(:build_step_params)
+
+    assert_equal runner.instance_variable_get(:@config), params[:config]
+  end
+
   private
 
   def build_runner(step_classes, step_instances)


### PR DESCRIPTION
## Why

`Step#initialize` and `Migration#initialize` each built their own `Config` via `Config.new(dotfiles_dir, system:)`, so `config/config.yml` was parsed once per step and migration (30+ times per `dotf run`). `Runner` and `MigrationRunner` already construct a `Config`.

## What

- Add an optional `config:` param to `Step#initialize` and `Migration#initialize`; when provided, reuse it instead of building a new one.
- `Runner#build_step_params` and `MigrationRunner#migration_params` now pass their shared `@config`.
- The param defaults to `nil` → `Config.new`, so existing test constructors that build steps with a fake system and no shared config keep working unchanged. Steps only ever read `@config` (no mutations), so sharing the cached instance is safe.

## Tests

New `test_build_step_params_shares_runner_config` asserts the runner's config is the one passed to steps. 420 runs, 0 failures; standardrb/flay/dead-code clean.