### PR TITLE
Extract shared CommandHelpers and PlatformRestrictable modules

### DIFF
--- a/lib/dotfiles/command_helpers.rb
+++ b/lib/dotfiles/command_helpers.rb
@@ -1,0 +1,27 @@
+class Dotfiles
+  # Shared command-construction and execution helpers used by both
+  # Dotfiles::Step and Dotfiles::Migration. The includer must provide
+  # `@system` (an object responding to #execute, like SystemAdapter).
+  module CommandHelpers
+    def command(*parts)
+      Dotfiles::Command.argv(*parts)
+    end
+
+    def env_command(vars, *parts)
+      Dotfiles::Command.env(vars, *parts)
+    end
+
+    def shell_script(script, *args)
+      command("bash", "-c", script, "dotfiles", *args)
+    end
+
+    def command_succeeds?(command)
+      _, status = @system.execute(command)
+      status == 0
+    end
+
+    def command_exists?(command)
+      command_succeeds?(shell_script('command -v -- "$1" >/dev/null 2>&1', command))
+    end
+  end
+end

--- a/lib/dotfiles/loader.rb
+++ b/lib/dotfiles/loader.rb
@@ -15,6 +15,8 @@ class Dotfiles
     def self.require_core
       require "config"
       require "command"
+      require "command_helpers"
+      require "platform_restrictable"
       require "system_adapter"
       require "home_file_set"
       require "step"

--- a/lib/dotfiles/migration.rb
+++ b/lib/dotfiles/migration.rb
@@ -2,6 +2,11 @@ class Dotfiles
   class Migration
     @@migrations = []
 
+    extend Dotfiles::PlatformRestrictable
+    include Dotfiles::CommandHelpers
+
+    private :command, :env_command, :shell_script, :command_succeeds?, :command_exists?
+
     def self.inherited(subclass)
       @@migrations << subclass
     end
@@ -16,22 +21,6 @@ class Dotfiles
 
     def self.display_name
       name.gsub(/^Dotfiles::Migration::/, "").gsub(/([A-Z]+)([A-Z][a-z])/, '\\1 \\2').gsub(/([a-z\d])([A-Z])/, '\\1 \\2')
-    end
-
-    def self.macos_only
-      @macos_only = true
-    end
-
-    def self.macos_only?
-      @macos_only || false
-    end
-
-    def self.debian_only
-      @debian_only = true
-    end
-
-    def self.debian_only?
-      @debian_only || false
     end
 
     def initialize(debug:, dotfiles_repo:, dotfiles_dir:, home:, system: SystemAdapter.new)
@@ -57,30 +46,9 @@ class Dotfiles
       @system.execute(command, quiet: quiet)
     end
 
-    def command(*parts)
-      Dotfiles::Command.argv(*parts)
-    end
-
-    def env_command(vars, *parts)
-      Dotfiles::Command.env(vars, *parts)
-    end
-
-    def shell_script(script, *args)
-      command("bash", "-c", script, "dotfiles", *args)
-    end
-
-    def command_succeeds?(command)
-      _, status = @system.execute(command)
-      status == 0
-    end
-
     def platform_requirement_met?(platform)
       predicate = "#{platform}_only?"
       !self.class.public_send(predicate) || @system.public_send("#{platform}?")
-    end
-
-    def command_exists?(command)
-      command_succeeds?(shell_script('command -v -- "$1" >/dev/null 2>&1', command))
     end
   end
 end

--- a/lib/dotfiles/platform_restrictable.rb
+++ b/lib/dotfiles/platform_restrictable.rb
@@ -1,0 +1,23 @@
+class Dotfiles
+  # Marks a class as restricted to a platform. Extend this module in a
+  # Step or Migration base class to get macos_only/debian_only DSL and
+  # predicates. The includer's instances are expected to provide
+  # `@system` (responding to #macos?/#debian?) for allowed_on_platform?.
+  module PlatformRestrictable
+    def macos_only
+      @macos_only = true
+    end
+
+    def macos_only?
+      @macos_only || false
+    end
+
+    def debian_only
+      @debian_only = true
+    end
+
+    def debian_only?
+      @debian_only || false
+    end
+  end
+end

--- a/lib/dotfiles/step.rb
+++ b/lib/dotfiles/step.rb
@@ -5,28 +5,17 @@ class Dotfiles
   class Step
     @@steps = []
 
+    extend Dotfiles::PlatformRestrictable
+    include Dotfiles::CommandHelpers
+
+    private :command, :env_command, :shell_script, :command_succeeds?, :command_exists?
+
     def self.inherited(subclass)
       @@steps << subclass
     end
 
     def self.depends_on
       []
-    end
-
-    def self.macos_only
-      @macos_only = true
-    end
-
-    def self.macos_only?
-      @macos_only || false
-    end
-
-    def self.debian_only
-      @debian_only = true
-    end
-
-    def self.debian_only?
-      @debian_only || false
     end
 
     def self.system_packages_steps
@@ -153,20 +142,8 @@ class Dotfiles
       @system.execute(cmd, quiet: quiet)
     end
 
-    def command(*parts)
-      Dotfiles::Command.argv(*parts)
-    end
-
-    def env_command(vars, *parts)
-      Dotfiles::Command.env(vars, *parts)
-    end
-
     def sudo_command(*parts)
       root? ? command(*parts) : command("sudo", *parts)
-    end
-
-    def shell_script(script, *args)
-      command("bash", "-c", script, "dotfiles", *args)
     end
 
     def format_command_error(command, status, output)
@@ -175,15 +152,6 @@ class Dotfiles
       return "#{display_command} failed (status #{status})" if cleaned.empty?
 
       "#{display_command} failed (status #{status}): #{cleaned}"
-    end
-
-    def command_succeeds?(command)
-      _, status = @system.execute(command)
-      status == 0
-    end
-
-    def command_exists?(command)
-      command_succeeds?(shell_script('command -v -- "$1" >/dev/null 2>&1', command))
     end
 
     def brew_quiet(*args)


### PR DESCRIPTION
## Why

`Step` and `Migration` duplicated five identical private helpers (`command`, `env_command`, `shell_script`, `command_succeeds?`, `command_exists?`) and four identical class-level platform DSL methods (`macos_only`, `macos_only?`, `debian_only`, `debian_only?`). One fix to command construction meant two edits, and the two bases could drift.

## What

- New `Dotfiles::CommandHelpers` (instance methods) — `include`d in both `Step` and `Migration`.
- New `Dotfiles::PlatformRestrictable` (class methods) — `extend`ed in both.
- The included helpers are re-declared `private` in each base so they stay out of the public interface (the `StepPublicMethods` cop only inspects `lib/dotfiles/steps/*`, but keeping them private preserves the existing contract).
- `execute` and `allowed_on_platform?` stay in each base because they genuinely differ (`Step#execute` debugs via `run_command`; the two `allowed_on_platform?` implementations differ).

## Tests

419 runs, 0 failures; full lint suite clean (standardrb/flog/flay/dead-code/complexity/secrets/human-only/large-files).