### PR TITLE
Route runner validation through collect_errors

### DIFF
--- a/lib/dotfiles/runner.rb
+++ b/lib/dotfiles/runner.rb
@@ -175,12 +175,14 @@ class Dotfiles
     def build_step_data(step_class, index)
       step = @step_instances[index]
       step_name = step_class.display_name
-      complete = if step.allowed_on_platform?
-        Dotfiles.debug_benchmark("Complete check: #{step_name}") { !!step.complete? }
+      if step.allowed_on_platform?
+        collected = Dotfiles.debug_benchmark("Complete check: #{step_name}") { step.collect_errors }
+        complete = collected.empty?
       else
-        true
+        collected = []
+        complete = true
       end
-      {index: index, name: step_name, complete: complete, step: step}
+      {index: index, name: step_name, complete: complete, step: step, errors: collected}
     end
 
     def merge_step_result(data, results)
@@ -208,7 +210,7 @@ class Dotfiles
     end
 
     def append_step_errors(data, results)
-      results[:errors].concat(data[:step].errors.map { |err| {step: data[:name], message: err} })
+      results[:errors].concat(data[:errors].map { |err| {step: data[:name], message: err} })
     end
   end
 end

--- a/lib/dotfiles/step.rb
+++ b/lib/dotfiles/step.rb
@@ -132,6 +132,18 @@ class Dotfiles
       false
     end
 
+    # Validate the step and return its error messages. This is the explicit
+    # entry point for collecting errors for display; it clears @errors, runs
+    # the complete? check (which populates @errors), and returns a duplicate
+    # of the collected errors. complete? remains a boolean predicate that
+    # callers can use directly, but the Runner routes validation through here
+    # so the display path does not depend on the predicate's side effect.
+    def collect_errors
+      @errors.clear
+      complete?
+      errors.dup
+    end
+
     def allowed_on_platform?
       return false if self.class.macos_only? && !@system.macos?
       return false if self.class.debian_only? && !@system.debian?

--- a/test/dotfiles/step_test.rb
+++ b/test/dotfiles/step_test.rb
@@ -12,6 +12,17 @@ class StepTest < Minitest::Test
     end
   end
 
+  class TestStepWithError < Dotfiles::Step
+    def run
+    end
+
+    def complete?
+      super
+      add_error("not done")
+      false
+    end
+  end
+
   class TestStepB < Dotfiles::Step
     def self.depends_on
       [TestStepA]
@@ -124,22 +135,6 @@ class StepTest < Minitest::Test
     assert_empty missing.map(&:name)
   end
 
-  private
-
-  def production_steps
-    Dotfiles::Step.all_steps.select { |step| step.name&.start_with?("Dotfiles::Step::") }
-  end
-
-  def assert_collection(collection_method, add_method, title:, message:)
-    step = create_step(TestStepA)
-    step.send(add_method, title: title, message: message)
-
-    collection = step.send(collection_method)
-    assert_equal 1, collection.length
-    assert_equal title, collection.first[:title]
-    assert_equal message, collection.first[:message]
-  end
-
   def test_ran_tracking
     step = create_step(TestStepA)
     refute step.ran?
@@ -170,6 +165,39 @@ class StepTest < Minitest::Test
     step.complete?
 
     assert_empty step.errors
+  end
+
+  def test_collect_errors_returns_errors_from_complete_check
+    step = create_step(TestStepA)
+    step.add_error("Stale error")
+
+    assert_equal [], step.collect_errors
+    assert_empty step.errors
+  end
+
+  def test_collect_errors_reflects_validation_errors
+    step = create_step(TestStepWithError)
+
+    errors = step.collect_errors
+
+    refute_empty errors
+    assert_equal step.errors, errors
+  end
+
+  private
+
+  def production_steps
+    Dotfiles::Step.all_steps.select { |step| step.name&.start_with?("Dotfiles::Step::") }
+  end
+
+  def assert_collection(collection_method, add_method, title:, message:)
+    step = create_step(TestStepA)
+    step.send(add_method, title: title, message: message)
+
+    collection = step.send(collection_method)
+    assert_equal 1, collection.length
+    assert_equal title, collection.first[:title]
+    assert_equal message, collection.first[:message]
   end
 end
 

--- a/test/support/fake_runner_step.rb
+++ b/test/support/fake_runner_step.rb
@@ -26,6 +26,10 @@ class FakeRunnerStep < Struct.new(:allowed, :complete_value, :should_run_value, 
     complete_value
   end
 
+  def collect_errors
+    errors
+  end
+
   def ran?
     instance_variable_get(:@ran) || run_calls.positive?
   end


### PR DESCRIPTION
## Why

The Runner currently calls `complete?` and then reads `step.errors`, relying on `complete?`'s side effect to populate display errors. That couples the status predicate and display error collection.

A full conversion of all step validation logic out of `complete?` is large/risky right now: there are 65 `add_error` calls across 30+ files, plus prepended/included modules like `Defaultable` and `Protectable` whose `super` chains currently depend on the existing contract. This PR adds the explicit API and routes the Runner through it without changing individual step semantics.

## What

- Add `Step#collect_errors` as the explicit validation/display API.
  - Clears stale errors.
  - Runs the existing `complete?` check, preserving current subclass/module behavior.
  - Returns a duplicate of the collected errors.
- Update `Runner#build_step_data` to call `collect_errors` once and derive both status and display errors from that result.
- Update `append_step_errors` to use the collected errors instead of reading `step.errors` after the predicate call.
- Add `FakeRunnerStep#collect_errors` for runner tests.
- Add coverage for `collect_errors`.

## Test fix included

`step_test.rb` had helper methods marked `private` before several later `test_*` methods. Minitest does not run private test methods, so those tests were accidentally invisible. This moves helpers to the end of the class so the existing tests and new `collect_errors` tests run. The suite increases from 419 to 425 tests.

## Tests

425 runs, 776 assertions, 0 failures. Full lint suite clean.