### PR TITLE
Add CI no-op convergence check

### DIFF
--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -122,6 +122,7 @@ jobs:
         name: logs-${{ matrix.os }}
         path: |
           output.log
+          output-second.log
           fish-init.log
         retention-days: 7
 
@@ -237,5 +238,6 @@ jobs:
         name: logs-macos-latest-non-admin
         path: |
           /Users/dotfiles-ci/dotfiles/output.log
+          /Users/dotfiles-ci/dotfiles/output-second.log
           /Users/dotfiles-ci/dotfiles/fish-init.log
         retention-days: 7

--- a/lib/dotfiles/steps/debian/update_debian_step.rb
+++ b/lib/dotfiles/steps/debian/update_debian_step.rb
@@ -10,7 +10,7 @@ class Dotfiles::Step::UpdateDebianStep < Dotfiles::Step
   end
 
   def should_run?
-    release_updates_available.any?
+    !ci_or_noninteractive? && release_updates_available.any?
   end
 
   def run

--- a/lib/dotfiles/steps/install_system_packages_step.rb
+++ b/lib/dotfiles/steps/install_system_packages_step.rb
@@ -6,11 +6,11 @@ class Dotfiles::Step::InstallSystemPackagesStep < Dotfiles::Step
   end
 
   def should_run?
-    package_args.any?
+    missing_package_args.any?
   end
 
   def run
-    return if package_args.empty?
+    return if missing_package_args.empty?
 
     @install_error = nil
     install_commands.each do |install_command|
@@ -25,6 +25,7 @@ class Dotfiles::Step::InstallSystemPackagesStep < Dotfiles::Step
   def complete?
     super
     add_error(@install_error) if @install_error
+    missing_package_args.each { |package| add_error("System package not installed: #{package}") }
     @errors.empty?
   end
 
@@ -38,7 +39,7 @@ class Dotfiles::Step::InstallSystemPackagesStep < Dotfiles::Step
   end
 
   def mise_install_command
-    env_command({"MISE_EXPERIMENTAL" => "1"}, "mise", "system", "install", "--yes", "--update", *package_args)
+    env_command({"MISE_EXPERIMENTAL" => "1"}, "mise", "system", "install", "--yes", "--update", *missing_package_args)
   end
 
   def apt_update_command
@@ -46,15 +47,23 @@ class Dotfiles::Step::InstallSystemPackagesStep < Dotfiles::Step
   end
 
   def apt_install_command
-    sudo_command("env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "install", "-y", *apt_packages)
+    sudo_command("env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "install", "-y", *missing_apt_packages)
   end
 
   def brew_install_command
-    env_command({"HOMEBREW_NO_AUTO_UPDATE" => "1", "HOMEBREW_NO_ENV_HINTS" => "1"}, "brew", "install", *brew_packages)
+    env_command({"HOMEBREW_NO_AUTO_UPDATE" => "1", "HOMEBREW_NO_ENV_HINTS" => "1"}, "brew", "install", *missing_brew_packages)
   end
 
-  def package_args
-    @package_args ||= (brew_packages.map { |package| "brew:#{package}" } + apt_packages.map { |package| "apt:#{package}" }).uniq
+  def missing_package_args
+    (missing_brew_packages.map { |package| "brew:#{package}" } + missing_apt_packages.map { |package| "apt:#{package}" }).uniq
+  end
+
+  def missing_brew_packages
+    brew_packages.reject { |package| brew_package_installed?(package) }
+  end
+
+  def missing_apt_packages
+    apt_packages.reject { |package| apt_package_installed?(package) }
   end
 
   def brew_packages
@@ -69,6 +78,19 @@ class Dotfiles::Step::InstallSystemPackagesStep < Dotfiles::Step
 
     packages = @config.debian_packages - @config.debian_non_apt_packages
     packages.reject { |package| package == "docker.io" && command_exists?("docker") }
+  end
+
+  def brew_package_installed?(package)
+    command_succeeds?(
+      env_command(
+        {"HOMEBREW_NO_AUTO_UPDATE" => "1", "HOMEBREW_NO_ENV_HINTS" => "1"},
+        "brew", "list", "--formula", package
+      )
+    )
+  end
+
+  def apt_package_installed?(package)
+    command_succeeds?(command("dpkg", "-s", package))
   end
 
   def mise_system_available?

--- a/test/dotfiles/steps/debian/update_debian_step_test.rb
+++ b/test/dotfiles/steps/debian/update_debian_step_test.rb
@@ -17,6 +17,12 @@ class UpdateDebianStepTest < StepTestCase
     assert_should_run
   end
 
+  def test_should_not_run_in_ci_when_release_update_available
+    stub_release_update("99.99")
+
+    with_ci { refute_should_run }
+  end
+
   def test_incomplete_when_release_update_available
     stub_release_update("99.99")
 

--- a/test/dotfiles/steps/install_system_packages_step_test.rb
+++ b/test/dotfiles/steps/install_system_packages_step_test.rb
@@ -15,10 +15,45 @@ class InstallSystemPackagesStepTest < StepTestCase
     assert_complete
   end
 
+  def test_should_not_run_when_brew_packages_are_installed
+    @fake_system.stub_macos
+    @fake_system.stub_command("groups", "admin staff")
+    write_config(:brew, {"brew" => {"packages" => ["duti"], "casks" => []}})
+    stub_brew_package_installed("duti")
+
+    refute_should_run
+  end
+
+  def test_should_run_when_brew_package_is_missing
+    @fake_system.stub_macos
+    @fake_system.stub_command("groups", "admin staff")
+    write_config(:brew, {"brew" => {"packages" => ["duti"], "casks" => []}})
+    stub_brew_package_missing("duti")
+
+    assert_should_run
+  end
+
+  def test_should_not_run_when_apt_packages_are_installed
+    @fake_system.stub_debian
+    write_config("config", "packages" => {"trash" => {"debian" => "trash-cli"}})
+    stub_apt_package_installed("trash-cli")
+
+    refute_should_run
+  end
+
+  def test_should_run_when_apt_package_is_missing
+    @fake_system.stub_debian
+    write_config("config", "packages" => {"trash" => {"debian" => "trash-cli"}})
+    stub_apt_package_missing("trash-cli")
+
+    assert_should_run
+  end
+
   def test_run_installs_brew_packages_with_mise_on_macos
     @fake_system.stub_macos
     @fake_system.stub_command("groups", "admin staff")
     write_config(:brew, {"brew" => {"packages" => ["duti"], "casks" => []}})
+    stub_brew_package_missing("duti")
 
     step.run
 
@@ -28,6 +63,7 @@ class InstallSystemPackagesStepTest < StepTestCase
   def test_run_installs_apt_packages_with_mise_on_debian
     @fake_system.stub_debian
     write_config("config", "packages" => {"trash" => {"debian" => "trash-cli"}})
+    stub_apt_package_missing("trash-cli")
 
     step.run
 
@@ -39,6 +75,7 @@ class InstallSystemPackagesStepTest < StepTestCase
     @fake_system.stub_command("groups", "admin staff")
     @fake_system.stub_command("MISE_EXPERIMENTAL=1 mise system install --help", "no task system found", exit_status: 1)
     write_config(:brew, {"brew" => {"packages" => ["duti"], "casks" => []}})
+    stub_brew_package_missing("duti")
 
     step.run
 
@@ -49,6 +86,7 @@ class InstallSystemPackagesStepTest < StepTestCase
     @fake_system.stub_debian
     @fake_system.stub_command("MISE_EXPERIMENTAL=1 mise system install --help", "no task system found", exit_status: 1)
     write_config("config", "packages" => {"trash" => {"debian" => "trash-cli"}})
+    stub_apt_package_missing("trash-cli")
 
     step.run
 
@@ -79,11 +117,42 @@ class InstallSystemPackagesStepTest < StepTestCase
     @fake_system.stub_macos
     @fake_system.stub_command("groups", "admin staff")
     write_config(:brew, {"brew" => {"packages" => ["duti"], "casks" => []}})
+    stub_brew_package_missing("duti")
     @fake_system.stub_command("MISE_EXPERIMENTAL=1 mise system install --yes --update brew:duti", "boom", exit_status: 1)
 
     step.run
 
     refute step.complete?
     assert_includes step.errors.join("\n"), "mise system install"
+  end
+
+  private
+
+  def stub_brew_package_installed(package)
+    stub_brew_package_check(package, exit_status: 0)
+  end
+
+  def stub_brew_package_missing(package)
+    stub_brew_package_check(package, exit_status: 1)
+  end
+
+  def stub_brew_package_check(package, exit_status:)
+    @fake_system.stub_command(
+      "HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ENV_HINTS=1 brew list --formula #{package}",
+      "",
+      exit_status: exit_status
+    )
+  end
+
+  def stub_apt_package_installed(package)
+    stub_apt_package_check(package, exit_status: 0)
+  end
+
+  def stub_apt_package_missing(package)
+    stub_apt_package_check(package, exit_status: 1)
+  end
+
+  def stub_apt_package_check(package, exit_status:)
+    @fake_system.stub_command("dpkg -s #{package}", "", exit_status: exit_status)
   end
 end

--- a/tools/ci/run_dotfiles_integration.sh
+++ b/tools/ci/run_dotfiles_integration.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 repo_dir="${1:-$PWD}"
-output_log="$repo_dir/output.log"
 fish_log="$repo_dir/fish-init.log"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -11,9 +10,24 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$script_dir/package_probe.sh"
 
 run_dotfiles() {
+    local log_name="${1:-output.log}"
+
     cd "$repo_dir"
     chmod +x bin/dotf
-    ./bin/dotf run 2>&1 | tee "$output_log"
+    ./bin/dotf run 2>&1 | tee "$repo_dir/$log_name"
+}
+
+assert_no_steps_ran() {
+    local label="$1"
+    local log_name="$2"
+    local log_path="$repo_dir/$log_name"
+
+    if grep -F "Running step:" "$log_path"; then
+        echo "❌ $label was not a no-op when converged"
+        return 1
+    fi
+
+    echo "✅ $label was a no-op when converged"
 }
 
 find_fish_bin() {
@@ -68,6 +82,8 @@ check_fish() {
 }
 
 check_ci_packages "Pre-run" assert_not_installed
-run_dotfiles
+run_dotfiles output.log
 check_ci_packages "Post-run" assert_installed
+run_dotfiles output-second.log
+assert_no_steps_ran "Second dotf run" output-second.log
 check_fish


### PR DESCRIPTION
Adds an integration check that runs `dotf run` a second time after a successful first run and fails if any step logs `Running step:`. This codifies the no-op-when-converged property and should currently fail for the system package install step.