### PR TITLE
Skip migrations on fresh machines

### DIFF
--- a/.debride-whitelist
+++ b/.debride-whitelist
@@ -9,4 +9,5 @@ install_direct_download
 log_file
 packages=
 print_steps
+run_if_existing_machine
 running_codespaces?

--- a/bin/dotf
+++ b/bin/dotf
@@ -182,7 +182,7 @@ cmd_run() {
     ensure_mise_env
 
     cd "$DOTFILES_DIR"
-    ruby -r ./lib/dotfiles.rb -e "Dotfiles::MigrationRunner.new('$LOG_FILE').run"
+    ruby -r ./lib/dotfiles.rb -e "Dotfiles::MigrationRunner.new('$LOG_FILE').run_if_existing_machine"
     ruby -r ./lib/dotfiles.rb -e "Dotfiles::Runner.new('$LOG_FILE').run"
 
     debug "Run complete"

--- a/lib/dotfiles/migration_runner.rb
+++ b/lib/dotfiles/migration_runner.rb
@@ -20,6 +20,15 @@ class Dotfiles
       abort "Error: #{e.message}"
     end
 
+    def run_if_existing_machine
+      return run if existing_machine?
+
+      mark_version(latest_migration_version)
+      puts "Skipping migrations on fresh machine."
+    rescue => e
+      abort "Error: #{e.message}"
+    end
+
     def current_version
       return 0 unless @system.file_exist?(version_file)
 
@@ -31,6 +40,14 @@ class Dotfiles
     end
 
     private
+
+    def existing_machine?
+      @system.file_exist?(version_file) || @system.file_exist?(dotf_command_file)
+    end
+
+    def latest_migration_version
+      Migration.all_migrations.map(&:version).max || 0
+    end
 
     def run_migration(migration_class)
       migration = migration_class.new(**migration_params)
@@ -62,6 +79,10 @@ class Dotfiles
 
     def version_file
       File.join(@home, ".local", "state", "dotf", "migration_version")
+    end
+
+    def dotf_command_file
+      File.join(@home, ".local", "bin", "dotf")
     end
   end
 end

--- a/test/dotfiles/dotf_cli_test.rb
+++ b/test/dotfiles/dotf_cli_test.rb
@@ -85,7 +85,7 @@ class DotfCliTest < Minitest::Test
     end
   end
 
-  def test_run_runs_migrations_before_setup_steps
+  def test_run_runs_existing_machine_migrations_before_setup_steps
     with_dotf_script do |tmpdir, script_path, _logs_dir|
       log_path = File.join(tmpdir, "run-commands.log")
       File.write(File.join(tmpdir, "bin", "bootstrap"), bootstrap_stub(log_path))
@@ -129,7 +129,7 @@ class DotfCliTest < Minitest::Test
     commands = File.readlines(log_path, chomp: true)
     assert_equal "bootstrap", commands[0]
     assert_equal "mise activate bash", commands[1]
-    assert_match(/\Aruby -r \.\/lib\/dotfiles\.rb -e Dotfiles::MigrationRunner\.new\('.+'\)\.run\z/, commands[2])
+    assert_match(/\Aruby -r \.\/lib\/dotfiles\.rb -e Dotfiles::MigrationRunner\.new\('.+'\)\.run_if_existing_machine\z/, commands[2])
     assert_match(/\Aruby -r \.\/lib\/dotfiles\.rb -e Dotfiles::Runner\.new\('.+'\)\.run\z/, commands[3])
     assert_equal 4, commands.size
   end

--- a/test/dotfiles/migration_runner_test.rb
+++ b/test/dotfiles/migration_runner_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+class MigrationRunnerTest < Minitest::Test
+  def setup
+    super
+    @original_migrations = Dotfiles::Migration.class_variable_get(:@@migrations).dup
+  end
+
+  def teardown
+    Dotfiles::Migration.class_variable_set(:@@migrations, @original_migrations)
+    super
+  end
+
+  def test_run_if_existing_machine_skips_and_marks_latest_version_on_fresh_machine
+    build_migration_class(900000000001)
+    runner = build_runner
+
+    capture_io { runner.run_if_existing_machine }
+
+    assert_equal "900000000001\n", @fake_system.read_file(version_file)
+    refute @fake_system.file_exist?(ran_file)
+  end
+
+  def test_run_if_existing_machine_runs_when_dotf_command_exists
+    build_migration_class(900000000001)
+    @fake_system.stub_file_content(File.join(@home, ".local", "bin", "dotf"), "dotf")
+    runner = build_runner
+
+    capture_io { runner.run_if_existing_machine }
+
+    assert_equal "yes", @fake_system.read_file(ran_file)
+    assert_equal "900000000001\n", @fake_system.read_file(version_file)
+  end
+
+  def test_run_if_existing_machine_runs_when_version_file_exists
+    build_migration_class(900000000001)
+    @fake_system.stub_file_content(version_file, "0\n")
+    runner = build_runner
+
+    capture_io { runner.run_if_existing_machine }
+
+    assert_equal "yes", @fake_system.read_file(ran_file)
+    assert_equal "900000000001\n", @fake_system.read_file(version_file)
+  end
+
+  def test_run_still_runs_without_existing_machine_marker
+    build_migration_class(900000000001)
+    runner = build_runner
+
+    capture_io { runner.run }
+
+    assert_equal "yes", @fake_system.read_file(ran_file)
+  end
+
+  private
+
+  def build_runner
+    Dotfiles::MigrationRunner.new(nil, system: @fake_system, home: @home, dotfiles_dir: @dotfiles_dir, debug: false)
+  end
+
+  def build_migration_class(version)
+    Class.new(Dotfiles::Migration) do
+      const_set(:VERSION, version)
+
+      define_singleton_method(:name) { "Dotfiles::Migration::TestMigration#{version}" }
+
+      define_method(:up) do
+        @system.write_file(File.join(@home, "migration-ran"), "yes")
+      end
+
+      define_method(:down) {}
+    end
+  end
+
+  def version_file
+    File.join(@home, ".local", "state", "dotf", "migration_version")
+  end
+
+  def ran_file
+    File.join(@home, "migration-ran")
+  end
+end


### PR DESCRIPTION
Fixes #431.\n\nChanges:\n- Adds a migration-runner path for `dotf run` that skips historical migrations on fresh machines.\n- Marks fresh machines at the latest migration version so future migrations can still apply.\n- Keeps explicit `dotf migrate` behavior unchanged.\n- Adds migration-runner coverage for fresh and existing machine markers.