### PR TITLE
Raise on migration command failures

### DIFF
--- a/.debride-whitelist
+++ b/.debride-whitelist
@@ -4,7 +4,6 @@ applications=
 config=
 copy_if_exists
 down
-execute!
 install_direct_download
 log_file
 packages=

--- a/lib/dotfiles/migration.rb
+++ b/lib/dotfiles/migration.rb
@@ -43,7 +43,7 @@ class Dotfiles
     private
 
     def execute(command, quiet: true)
-      @system.execute(command, quiet: quiet)
+      @system.execute!(command, quiet: quiet)
     end
 
     def platform_requirement_met?(platform)

--- a/lib/dotfiles/migrations/202605310002_reinstall_npm_mise_tools_with_aube.rb
+++ b/lib/dotfiles/migrations/202605310002_reinstall_npm_mise_tools_with_aube.rb
@@ -38,7 +38,10 @@ class Dotfiles::Migration::ReinstallNpmMiseToolsWithAube < Dotfiles::Migration
   end
 
   def aube_mise_command(*args)
-    env_command({"MISE_NPM_PACKAGE_MANAGER" => "aube"}, *mise_command(*args))
+    env_command(
+      {"MISE_NPM_PACKAGE_MANAGER" => "aube"},
+      "mise", "--cd", @home, "x", AUBE_TOOL, "--", "mise", "--cd", @home, *args
+    )
   end
 
   def mise_command(*args)

--- a/lib/dotfiles/migrations/202606120001_reinstall_dotfiles_hk_hook.rb
+++ b/lib/dotfiles/migrations/202606120001_reinstall_dotfiles_hk_hook.rb
@@ -19,8 +19,15 @@ class Dotfiles::Migration::ReinstallDotfilesHkHook < Dotfiles::Migration
   private
 
   def uninstall_legacy_hook_config
-    execute(git_command("config", "--local", "--unset-all", "hook.#{LEGACY_HOOK_NAME}.command"))
-    execute(git_command("config", "--local", "--unset-all", "hook.#{LEGACY_HOOK_NAME}.event"))
+    unset_legacy_hook_config("command")
+    unset_legacy_hook_config("event")
+  end
+
+  def unset_legacy_hook_config(key)
+    config_key = "hook.#{LEGACY_HOOK_NAME}.#{key}"
+    return unless command_succeeds?(git_command("config", "--local", "--get-all", config_key))
+
+    execute(git_command("config", "--local", "--unset-all", config_key))
   end
 
   def git_command(*args)

--- a/test/dotfiles/migration_test.rb
+++ b/test/dotfiles/migration_test.rb
@@ -1,6 +1,18 @@
 require "test_helper"
 
 class MigrationTest < Minitest::Test
+  include SystemAssertions
+
+  def setup
+    super
+    @original_migrations = Dotfiles::Migration.class_variable_get(:@@migrations).dup
+  end
+
+  def teardown
+    Dotfiles::Migration.class_variable_set(:@@migrations, @original_migrations)
+    super
+  end
+
   def test_macos_only_migration_is_allowed_on_macos
     @fake_system.stub_macos
     migration = create_migration(Dotfiles::Migration::MigrateBrewTapsToMise)
@@ -14,7 +26,90 @@ class MigrationTest < Minitest::Test
     refute migration.allowed_on_platform?
   end
 
+  def test_execute_raises_on_nonzero_status
+    migration = create_migration(executing_migration_class("boom", quiet: false))
+    @fake_system.stub_command("boom", "failed", exit_status: 1)
+
+    error = assert_raises(RuntimeError) { migration.up }
+
+    assert_includes error.message, "Command failed: boom"
+    assert_executed!("boom", quiet: false)
+  end
+
+  def test_command_succeeds_remains_non_raising
+    migration = create_migration(command_succeeds_migration_class("maybe"))
+    @fake_system.stub_command("maybe", "no", exit_status: 1)
+
+    migration.up
+
+    assert_equal "false", @fake_system.read_file(File.join(@home, "command-succeeded"))
+  end
+
+  def test_hk_hook_migration_skips_absent_legacy_config
+    @fake_system.mkdir_p(File.join(@dotfiles_dir, ".git"))
+    stub_legacy_hook_config_absent
+    migration = create_migration(Dotfiles::Migration::ReinstallDotfilesHkHook)
+
+    migration.up
+
+    refute_executed!("git -C #{@dotfiles_dir} config --local --unset-all hook.hk-pre-commit.command")
+    refute_executed!("git -C #{@dotfiles_dir} config --local --unset-all hook.hk-pre-commit.event")
+    assert_executed!(hk_install_command)
+  end
+
+  def test_hk_hook_migration_removes_present_legacy_config
+    @fake_system.mkdir_p(File.join(@dotfiles_dir, ".git"))
+    stub_legacy_hook_config_present
+    migration = create_migration(Dotfiles::Migration::ReinstallDotfilesHkHook)
+
+    migration.up
+
+    assert_executed!("git -C #{@dotfiles_dir} config --local --unset-all hook.hk-pre-commit.command")
+    assert_executed!("git -C #{@dotfiles_dir} config --local --unset-all hook.hk-pre-commit.event")
+  end
+
   private
+
+  def executing_migration_class(command_name, quiet: true)
+    Class.new(Dotfiles::Migration) do
+      const_set(:VERSION, 900000000001)
+      define_method(:up) { execute(command(command_name), quiet: quiet) }
+      define_method(:down) {}
+    end
+  end
+
+  def command_succeeds_migration_class(command_name)
+    Class.new(Dotfiles::Migration) do
+      const_set(:VERSION, 900000000002)
+      define_method(:up) do
+        result = command_succeeds?(command(command_name))
+        @system.write_file(File.join(@home, "command-succeeded"), result.to_s)
+      end
+      define_method(:down) {}
+    end
+  end
+
+  def stub_legacy_hook_config_absent
+    stub_legacy_hook_config(exit_status: 1)
+  end
+
+  def stub_legacy_hook_config_present
+    stub_legacy_hook_config(exit_status: 0)
+  end
+
+  def stub_legacy_hook_config(exit_status:)
+    %w[command event].each do |key|
+      @fake_system.stub_command("git -C #{@dotfiles_dir} config --local --get-all hook.hk-pre-commit.#{key}", "", exit_status: exit_status)
+    end
+  end
+
+  def hk_install_command
+    ["bash", "-c", 'cd "$1" && hk install', "dotfiles", @dotfiles_dir]
+  end
+
+  def refute_executed!(command)
+    refute @fake_system.received_operation?(:execute!, command, {quiet: true})
+  end
 
   def create_migration(migration_class, **overrides)
     defaults = {

--- a/test/dotfiles/migration_test.rb
+++ b/test/dotfiles/migration_test.rb
@@ -45,6 +45,15 @@ class MigrationTest < Minitest::Test
     assert_equal "false", @fake_system.read_file(File.join(@home, "command-succeeded"))
   end
 
+  def test_npm_mise_migration_runs_mise_with_aube_on_path
+    migration = create_migration(Dotfiles::Migration::ReinstallNpmMiseToolsWithAube)
+    stub_only_heroku_installed
+
+    migration.up
+
+    assert_executed!("MISE_NPM_PACKAGE_MANAGER=aube mise --cd #{@home} x github:jdx/aube -- mise --cd #{@home} install --yes heroku")
+  end
+
   def test_hk_hook_migration_skips_absent_legacy_config
     @fake_system.mkdir_p(File.join(@dotfiles_dir, ".git"))
     stub_legacy_hook_config_absent
@@ -87,6 +96,12 @@ class MigrationTest < Minitest::Test
       end
       define_method(:down) {}
     end
+  end
+
+  def stub_only_heroku_installed
+    @fake_system.stub_command("mise --cd #{@home} where npm:@openai/codex", "", exit_status: 1)
+    @fake_system.stub_command("mise --cd #{@home} where npm:@earendil-works/pi-coding-agent", "", exit_status: 1)
+    @fake_system.stub_command("mise --cd #{@home} where heroku", "/tmp/heroku", exit_status: 0)
   end
 
   def stub_legacy_hook_config_absent


### PR DESCRIPTION
Fixes #432.\n\nChanges:\n- Makes migration `execute(...)` use the raising system adapter path.\n- Keeps predicate checks non-raising via `command_succeeds?`.\n- Avoids intentional nonzero `git config --unset-all` cases in the hk-hook migration by checking for legacy keys first.\n- Adds tests for raising execution and hk migration behavior.