### PR TITLE
Limit brew upgrades to managed formulae

### DIFF
--- a/bin/dotf
+++ b/bin/dotf
@@ -137,6 +137,40 @@ mise_system_available() {
     MISE_EXPERIMENTAL=1 mise system install --help &> /dev/null
 }
 
+managed_brew_formulae() {
+    if [ -n "${DOTF_MANAGED_BREW_FORMULAE:-}" ]; then
+        printf '%s\n' "$DOTF_MANAGED_BREW_FORMULAE" | tr ',' '\n' | awk '{$1=$1}; NF'
+        return 0
+    fi
+
+    (
+        cd "$DOTFILES_DIR"
+        ruby -r ./lib/dotfiles.rb -e 'puts Dotfiles::Config.new(ENV.fetch("DOTFILES_DIR")).brew_packages'
+    )
+}
+
+outdated_managed_brew_formulae() {
+    local formula outdated_formula
+    local managed_formulae=()
+    local outdated_formulae=()
+
+    while IFS= read -r formula; do
+        [ -n "$formula" ] && managed_formulae+=("$formula")
+    done < <(managed_brew_formulae)
+
+    [ ${#managed_formulae[@]} -gt 0 ] || return 0
+
+    while IFS= read -r formula; do
+        [ -n "$formula" ] && outdated_formulae+=("$formula")
+    done < <(env HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --quiet)
+
+    for outdated_formula in "${outdated_formulae[@]}"; do
+        for formula in "${managed_formulae[@]}"; do
+            [ "$outdated_formula" = "$formula" ] && printf '%s\n' "$outdated_formula"
+        done
+    done
+}
+
 is_debian() {
     [ "${DOTF_FORCE_NON_DEBIAN:-false}" = "true" ] && return 1
     [ "${DOTF_FORCE_DEBIAN:-false}" = "true" ] || [ -f /etc/debian_version ]
@@ -236,15 +270,25 @@ cmd_upgrade() {
     fi
 
     if command -v brew &> /dev/null; then
+        local brew_formulae=()
+        local formula
+
         announce "Checking Homebrew metadata"
         env HOMEBREW_AUTO_UPDATE_SECS="$HOMEBREW_AUTO_UPDATE_SECS" brew update-if-needed
 
-        announce "Upgrading Homebrew"
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade
+        while IFS= read -r formula; do
+            [ -n "$formula" ] && brew_formulae+=("$formula")
+        done < <(outdated_managed_brew_formulae)
 
-        announce "Cleaning Homebrew"
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew autoremove
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew cleanup
+        if [ ${#brew_formulae[@]} -gt 0 ]; then
+            announce "Upgrading managed Homebrew formulae"
+            env HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade "${brew_formulae[@]}"
+
+            announce "Cleaning upgraded Homebrew formulae"
+            env HOMEBREW_NO_AUTO_UPDATE=1 brew cleanup "${brew_formulae[@]}"
+        else
+            warn "No managed Homebrew formulae need upgrades"
+        fi
     elif is_debian; then
         warn "Skipping Homebrew (brew not found on PATH)"
     fi

--- a/lib/dotfiles/steps/mac/upgrade_brew_packages_step.rb
+++ b/lib/dotfiles/steps/mac/upgrade_brew_packages_step.rb
@@ -20,16 +20,21 @@ class Dotfiles::Step::UpgradeBrewPackagesStep < Dotfiles::Step
   private
 
   def check_outdated_packages
-    output, status = brew_quiet("outdated", "--quiet")
-    debug("brew outdated --quiet output: #{output.inspect}")
+    output, status = brew_quiet("outdated", "--formula", "--quiet")
+    debug("brew outdated --formula --quiet output: #{output.inspect}")
     return unless status == 0
 
-    packages = output.lines.map(&:strip).reject(&:empty?)
+    packages = managed_outdated_packages(output)
     return if packages.empty?
 
     add_notice(
       title: "🍺 Homebrew Updates Available",
-      message: "#{packages.count} package(s) have updates available.\n\nRun 'brew upgrade' to update them."
+      message: "#{packages.count} managed package(s) have updates available.\n\nRun 'brew upgrade #{packages.join(" ")}' to update them."
     )
+  end
+
+  def managed_outdated_packages(output)
+    outdated_packages = output.lines.map(&:strip).reject(&:empty?)
+    outdated_packages & @config.brew_packages
   end
 end

--- a/test/dotfiles/dotf_cli_test.rb
+++ b/test/dotfiles/dotf_cli_test.rb
@@ -23,7 +23,11 @@ class DotfCliTest < Minitest::Test
   def test_upgrade_updates_pi_extensions
     assert_upgrade_commands(
       stubs: %w[mise brew pi],
-      env: {"DOTF_FORCE_NON_DEBIAN" => "true"},
+      env: {
+        "DOTF_FORCE_NON_DEBIAN" => "true",
+        "DOTF_MANAGED_BREW_FORMULAE" => "duti,fish",
+        "DOTF_BREW_OUTDATED_FORMULAE" => "duti,unmanaged"
+      },
       expected: [
         "brew shellenv bash", "mise activate bash", "mise cache clear --yes", "mise plugins update",
         "mise outdated --json",
@@ -32,8 +36,30 @@ class DotfCliTest < Minitest::Test
         "mise prune --yes", "mise cache prune --yes", "MISE_EXPERIMENTAL=1 mise system install --help",
         "MISE_EXPERIMENTAL=1 mise system install --yes --update",
         "HOMEBREW_AUTO_UPDATE_SECS=604800 brew update-if-needed",
-        "HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade",
-        "HOMEBREW_NO_AUTO_UPDATE=1 brew autoremove", "HOMEBREW_NO_AUTO_UPDATE=1 brew cleanup"
+        "HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --quiet",
+        "HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade duti",
+        "HOMEBREW_NO_AUTO_UPDATE=1 brew cleanup duti"
+      ]
+    )
+  end
+
+  def test_upgrade_skips_brew_upgrade_when_no_managed_formulae_are_outdated
+    assert_upgrade_commands(
+      stubs: %w[mise brew],
+      env: {
+        "DOTF_FORCE_NON_DEBIAN" => "true",
+        "DOTF_MANAGED_BREW_FORMULAE" => "duti",
+        "DOTF_BREW_OUTDATED_FORMULAE" => "unmanaged"
+      },
+      expected: [
+        "brew shellenv bash", "mise activate bash", "mise cache clear --yes", "mise plugins update",
+        "mise outdated --json",
+        "mise up --dry-run --before 3d --yes", "mise up --before 3d --yes",
+        "mise install --before 3d --yes", "mise prune --yes", "mise cache prune --yes",
+        "MISE_EXPERIMENTAL=1 mise system install --help",
+        "MISE_EXPERIMENTAL=1 mise system install --yes --update",
+        "HOMEBREW_AUTO_UPDATE_SECS=604800 brew update-if-needed",
+        "HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --quiet"
       ]
     )
   end

--- a/test/dotfiles/steps/upgrade_brew_packages_step_test.rb
+++ b/test/dotfiles/steps/upgrade_brew_packages_step_test.rb
@@ -1,18 +1,31 @@
 require "test_helper"
 
 class UpgradeBrewPackagesStepTest < Minitest::Test
+  include ConfigFixtureHelper
+
   def test_complete_returns_true
     step = create_step(Dotfiles::Step::UpgradeBrewPackagesStep)
     assert step.complete?
   end
 
-  def test_adds_notice_for_outdated_packages
+  def test_adds_notice_for_outdated_managed_packages
+    write_config("config", "packages" => {"fish" => {"brew" => "fish"}, "gh" => {"brew" => "gh"}})
     step = create_step(Dotfiles::Step::UpgradeBrewPackagesStep)
     @fake_system.stub_command(brew_outdated_command, "bat\nfish\ngh\n")
 
     step.should_run?
 
-    assert_brew_update_notice(step, "3 package(s)")
+    assert_brew_update_notice(step, "2 managed package(s)", "brew upgrade fish gh")
+  end
+
+  def test_no_notice_when_only_unmanaged_packages_are_outdated
+    write_config("config", "packages" => {"fish" => {"brew" => "fish"}})
+    step = create_step(Dotfiles::Step::UpgradeBrewPackagesStep)
+    @fake_system.stub_command(brew_outdated_command, "bat\n")
+
+    step.should_run?
+
+    assert_empty step.notices
   end
 
   def test_no_notice_when_packages_up_to_date
@@ -51,15 +64,15 @@ class UpgradeBrewPackagesStepTest < Minitest::Test
 
   private
 
-  def assert_brew_update_notice(step, count_message)
+  def assert_brew_update_notice(step, count_message, upgrade_command)
     assert_equal 1, step.notices.size
     notice = step.notices.first
     assert_includes notice[:title], "Homebrew Updates Available"
     assert_includes notice[:message], count_message
-    assert_includes notice[:message], "brew upgrade"
+    assert_includes notice[:message], upgrade_command
   end
 
   def brew_outdated_command
-    [{"HOMEBREW_NO_AUTO_UPDATE" => "1", "HOMEBREW_NO_ENV_HINTS" => "1"}, "brew", "outdated", "--quiet"]
+    [{"HOMEBREW_NO_AUTO_UPDATE" => "1", "HOMEBREW_NO_ENV_HINTS" => "1"}, "brew", "outdated", "--formula", "--quiet"]
   end
 end

--- a/test/support/dotf_script_helper.rb
+++ b/test/support/dotf_script_helper.rb
@@ -40,6 +40,9 @@ module DotfScriptHelper
         printf '%s ' "${env_prefix[@]}" >> "$DOTF_UPGRADE_LOG"
       fi
       printf '%s %s\n' "#{command}" "$*" >> "$DOTF_UPGRADE_LOG"
+      if [ "#{command}" = "brew" ] && [ "$*" = "outdated --formula --quiet" ]; then
+        printf '%s\n' "${DOTF_BREW_OUTDATED_FORMULAE:-}" | tr ',' '\n' | awk '{$1=$1}; NF'
+      fi
     BASH
     FileUtils.chmod("+x", path)
   end


### PR DESCRIPTION
Fixes #434.\n\nChanges:\n- Makes `dotf upgrade` compute repo-managed Homebrew formulae and only upgrade outdated formulae in that set.\n- Stops broad `brew upgrade`, `brew autoremove`, and global cleanup from `dotf upgrade`.\n- Updates Homebrew update notices to report only managed outdated formulae and show the targeted `brew upgrade ...` command.\n- Adds CLI and step coverage for managed vs unmanaged outdated formulae.