### PR TITLE
Speed up system package checks

### DIFF
--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -104,7 +104,7 @@ jobs:
         CI: true
         NONINTERACTIVE: true
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "fzf@latest,aqua:fish-shell/fish-shell"
+        MISE_CI_TOOLS: "fzf@latest,aqua:fish-shell/fish-shell@4.7.1"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_TAPS: ""
         BREW_CI_CASKS: ""
@@ -205,7 +205,7 @@ jobs:
         CI: true
         NONINTERACTIVE: true
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "fzf@latest,aqua:fish-shell/fish-shell"
+        MISE_CI_TOOLS: "fzf@latest,aqua:fish-shell/fish-shell@4.7.1"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_TAPS: ""
         BREW_CI_CASKS: ""

--- a/lib/dotfiles/steps/install_system_packages_step.rb
+++ b/lib/dotfiles/steps/install_system_packages_step.rb
@@ -59,7 +59,10 @@ class Dotfiles::Step::InstallSystemPackagesStep < Dotfiles::Step
   end
 
   def missing_brew_packages
-    brew_packages.reject { |package| brew_package_installed?(package) }
+    packages = brew_packages
+    return [] if packages.empty?
+
+    packages - installed_brew_packages(packages)
   end
 
   def missing_apt_packages
@@ -80,13 +83,14 @@ class Dotfiles::Step::InstallSystemPackagesStep < Dotfiles::Step
     packages.reject { |package| package == "docker.io" && command_exists?("docker") }
   end
 
-  def brew_package_installed?(package)
-    command_succeeds?(
+  def installed_brew_packages(packages)
+    output, _status = execute(
       env_command(
         {"HOMEBREW_NO_AUTO_UPDATE" => "1", "HOMEBREW_NO_ENV_HINTS" => "1"},
-        "brew", "list", "--formula", package
+        "brew", "list", "--formula", "--versions", *packages
       )
     )
+    output.lines.filter_map { |line| line.split.first }
   end
 
   def apt_package_installed?(package)

--- a/test/dotfiles/steps/install_system_packages_step_test.rb
+++ b/test/dotfiles/steps/install_system_packages_step_test.rb
@@ -33,6 +33,26 @@ class InstallSystemPackagesStepTest < StepTestCase
     assert_should_run
   end
 
+  def test_checks_brew_packages_in_bulk
+    @fake_system.stub_macos
+    @fake_system.stub_command("groups", "admin staff")
+    write_config(:brew, {"brew" => {"packages" => ["duti", "trash"], "casks" => []}})
+    stub_brew_packages_installed("duti", "trash")
+
+    refute_should_run
+
+    assert_equal 1, brew_list_versions_count
+  end
+
+  def test_should_run_when_one_brew_package_is_missing
+    @fake_system.stub_macos
+    @fake_system.stub_command("groups", "admin staff")
+    write_config(:brew, {"brew" => {"packages" => ["duti", "trash"], "casks" => []}})
+    stub_brew_packages_installed("duti", missing: ["trash"])
+
+    assert_should_run
+  end
+
   def test_should_not_run_when_apt_packages_are_installed
     @fake_system.stub_debian
     write_config("config", "packages" => {"trash" => {"debian" => "trash-cli"}})
@@ -129,19 +149,27 @@ class InstallSystemPackagesStepTest < StepTestCase
   private
 
   def stub_brew_package_installed(package)
-    stub_brew_package_check(package, exit_status: 0)
+    stub_brew_packages_installed(package)
   end
 
   def stub_brew_package_missing(package)
-    stub_brew_package_check(package, exit_status: 1)
+    stub_brew_packages_installed(missing: [package])
   end
 
-  def stub_brew_package_check(package, exit_status:)
+  def stub_brew_packages_installed(*installed, missing: [])
+    packages = installed + missing
+    output = installed.map { |package| "#{package} 1.0.0" }.join("\n")
     @fake_system.stub_command(
-      "HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ENV_HINTS=1 brew list --formula #{package}",
-      "",
-      exit_status: exit_status
+      "HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ENV_HINTS=1 brew list --formula --versions #{packages.join(" ")}",
+      output,
+      exit_status: missing.empty? ? 0 : 1
     )
+  end
+
+  def brew_list_versions_count
+    @fake_system.operations.count do |operation, command, _options|
+      operation == :execute && Dotfiles::Command.display(command).include?("brew list --formula --versions")
+    end
   end
 
   def stub_apt_package_installed(package)


### PR DESCRIPTION
## Summary
- replace per-package Homebrew install checks with one bulk `brew list --formula --versions` call
- keep missing-package detection when Homebrew exits nonzero for missing formulae
- add coverage for bulk checks and partial missing package output

## Benchmarks
- current per-package check: ~16.1s isolated for 28 packages, ~76.8s across should_run?/complete? in recent logs
- bulk `brew list --formula --versions <packages>`: ~0.51s per check

## Tests
- `bundle exec ruby -Itest test/dotfiles/steps/install_system_packages_step_test.rb`
- `bundle exec rake test`
- `bundle exec standardrb`
- pre-commit hook passed