### PR TITLE
Route npm family commands through aube shims

### DIFF
--- a/files/home/.config/fish/conf.d/socket-firewall.fish
+++ b/files/home/.config/fish/conf.d/socket-firewall.fish
@@ -1,7 +1,7 @@
 # Route supported package managers through Socket Firewall Free when sfw is installed.
-# Socket Firewall Free supports npm/yarn/pnpm, pip/uv, and cargo. Aube, mise,
-# Homebrew, and APT are intentionally not wrapped here because they are not
-# supported package-manager frontends for the free firewall.
+# npm/yarn/pnpm are intentionally not wrapped here so aube's shell shims can
+# route them through aube. Aube, mise, Homebrew, and APT are not supported
+# package-manager frontends for the free firewall.
 function __socket_firewall_enabled
   if set -q SOCKET_FIREWALL_DISABLE; and test "$SOCKET_FIREWALL_DISABLE" != "0"
     return 1
@@ -19,18 +19,6 @@ function __socket_firewall_run
   else
     command $tool $argv
   end
-end
-
-function npm --wraps npm --description "Run npm through Socket Firewall when available"
-  __socket_firewall_run npm $argv
-end
-
-function yarn --wraps yarn --description "Run yarn through Socket Firewall when available"
-  __socket_firewall_run yarn $argv
-end
-
-function pnpm --wraps pnpm --description "Run pnpm through Socket Firewall when available"
-  __socket_firewall_run pnpm $argv
 end
 
 function pip --wraps pip --description "Run pip through Socket Firewall when available"

--- a/files/home/.config/fish/config.fish
+++ b/files/home/.config/fish/config.fish
@@ -45,6 +45,9 @@ end
 if command -v mise >/dev/null 2>&1
   mise activate fish --no-hook-env | source
   mise hook-env -s fish | source
+  if command -q aube
+    aube activate fish | source
+  end
 
   function __mise_refresh_on_cd --on-variable PWD
     mise hook-env -s fish | source


### PR DESCRIPTION
## Summary
- activate aube's fish shims after mise activation
- stop wrapping npm, yarn, and pnpm with Socket Firewall fish functions so aube shims win

## Merge timing
This depends on aube 1.25.0, which was released 2026-06-25 03:28 UTC. With the repo's 3-day mise minimum release age, this should become mergeable after 2026-06-28 03:28 UTC (2026-06-28 12:28 JST).

## Tests
- fish -n files/home/.config/fish/config.fish files/home/.config/fish/conf.d/socket-firewall.fish
- bundle exec rake test