### PR TITLE
Remove dotf upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ When you run `dotf run` it will:
 
 | Command | What it does |
 |---------|--------------|
-| `dotf run` | Set up your Mac. Safe to run many times. |
-| `dotf upgrade` | Refresh and upgrade mise tools, Pi extensions, Homebrew packages, and APT packages on Debian/Ubuntu. Homebrew auto-updates are throttled to about once every 7 days. |
-| `dotf outdated` | Show managed package updates that match configured constraints and write a Pi upgrade prompt under `tmp/`. |
+| `dotf run` | Converge this host, including installing missing managed packages and applying safe local upgrades/pruning. Safe to run many times. |
+| `dotf outdated` | Show available upgrades for pinned mise tools, pinned Pi packages/extensions, and managed Homebrew packages, then write a Pi upgrade prompt under `tmp/`. |
 | `dotf steps` | List every setup step with its class name and description. |
 | `dotf help` | Show help |
 
@@ -57,7 +56,7 @@ Supported platforms:
 
 In general, because `mise` is crossplatform, if we can do it with `mise`, we should do it with `mise`.
 
-Managed tools are pinned to explicit versions. `dotf outdated` shows newer versions that match package-manager constraints and prints the `pi "$(cat tmp/pi-upgrade-prompt-...)"` command to start an update PR.
+Managed tools are pinned to explicit versions. `dotf run` converges the machine to those pins and handles safe local cleanup; `dotf outdated` reports newer pins to review and prints the `pi "$(cat tmp/pi-upgrade-prompt-...)"` command to start an update PR.
 
 `dotf run` aggressively overwrites existing user state. This repo is the source of truth.
 

--- a/bin/dotf
+++ b/bin/dotf
@@ -19,7 +19,6 @@ export DOTFILES_DIR
 source "$SCRIPT_DIR/lib/dotf-common.sh"
 LOGS_DIR="$DOTFILES_DIR/logs"
 LOG_RETENTION=30
-PACKAGE_UPGRADE_DELAY="${DOTF_PACKAGE_UPGRADE_DELAY:-3d}"
 HOMEBREW_AUTO_UPDATE_SECS="${DOTF_HOMEBREW_AUTO_UPDATE_SECS:-604800}"
 
 rotate_logs() {
@@ -41,8 +40,7 @@ rotate_logs() {
 
 DOTF_COMMANDS=(
     $'run\tSet up development environment from scratch'
-    $'upgrade\tRefresh and upgrade mise tools, system packages, Pi extensions, and Homebrew apps'
-    $'outdated\tShow managed package updates that match configured constraints'
+    $'outdated\tShow managed package updates and write a Pi PR prompt'
     $'migrate\tRun one-time migrations for existing machines'
     $'steps\tList every setup step with its class name and description'
     $'help\tShow this help message'
@@ -96,30 +94,6 @@ render_tsv_table() {
     fi
 }
 
-report_mise_updates() {
-    announce "Checking for mise updates"
-    (
-        unset BUNDLE_GEMFILE BUNDLE_BIN_PATH RUBYOPT GEM_HOME GEM_PATH 2>/dev/null || true
-        mise outdated --json 2>/dev/null | ruby -rjson -e '
-            begin
-              tools = JSON.parse(STDIN.read)
-            rescue JSON::ParserError
-              exit 0
-            end
-            semver = ->(v) { v.to_s.match?(/^v?\d+(?:\.\d+)*(?:[-+][0-9A-Za-z.-]+)?$/) }
-            actionable = tools.select do |_name, t|
-              semver.call(t["requested"]) && semver.call(t["current"]) && semver.call(t["latest"]) && t["current"] != t["latest"]
-            end
-            if actionable.empty?
-              puts "mise tools are up to date"
-            else
-              puts "#{actionable.size} tool(s) have updates available:"
-              actionable.each { |name, t| puts "  #{name}: #{t["current"]} -> #{t["latest"]}" }
-            end
-        '
-    )
-}
-
 ensure_homebrew_env() {
     if [ -x "$HOME/.homebrew/bin/brew" ]; then
         eval "$("$HOME/.homebrew/bin/brew" shellenv bash)"
@@ -140,10 +114,6 @@ ensure_mise_env() {
     if command -v mise &> /dev/null; then
         eval "$(mise activate bash)"
     fi
-}
-
-mise_system_available() {
-    MISE_EXPERIMENTAL=1 mise system install --help &> /dev/null
 }
 
 managed_brew_formulae() {
@@ -171,28 +141,6 @@ managed_brew_casks() {
           puts((config.brew_casks + config.applications.map { |app| app["brew_cask"] }).compact.uniq)
         '
     )
-}
-
-outdated_managed_brew_formulae() {
-    local formula outdated_formula
-    local managed_formulae=()
-    local outdated_formulae=()
-
-    while IFS= read -r formula; do
-        [ -n "$formula" ] && managed_formulae+=("$formula")
-    done < <(managed_brew_formulae)
-
-    [ ${#managed_formulae[@]} -gt 0 ] || return 0
-
-    while IFS= read -r formula; do
-        [ -n "$formula" ] && outdated_formulae+=("$formula")
-    done < <(env HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --quiet)
-
-    for outdated_formula in "${outdated_formulae[@]}"; do
-        for formula in "${managed_formulae[@]}"; do
-            [ "$outdated_formula" = "$formula" ] && printf '%s\n' "$outdated_formula"
-        done
-    done
 }
 
 is_debian() {
@@ -246,80 +194,6 @@ cmd_run() {
     debug "Run complete"
 }
 
-cmd_upgrade() {
-    acquire_dotf_lock
-    init_logging
-    debug "Starting dotf upgrade command"
-    is_debian || ensure_homebrew_env
-    ensure_mise_env
-
-    if ! command -v mise &> /dev/null; then
-        echo "Error: mise not found on PATH"
-        return 1
-    fi
-
-    if ! is_debian && ! command -v brew &> /dev/null; then
-        echo "Error: brew not found on PATH"
-        return 1
-    fi
-
-    announce "Refreshing mise metadata"
-    mise cache clear --yes
-    mise plugins update
-    report_mise_updates
-
-    announce "Checking for mise updates older than $PACKAGE_UPGRADE_DELAY"
-    mise up --dry-run --before "$PACKAGE_UPGRADE_DELAY" --yes
-
-    announce "Upgrading mise tools older than $PACKAGE_UPGRADE_DELAY"
-    mise up --before "$PACKAGE_UPGRADE_DELAY" --yes
-    mise install --before "$PACKAGE_UPGRADE_DELAY" --yes
-
-    if command -v pi &> /dev/null; then
-        announce "Updating Pi extensions"
-        pi update --extensions
-    else
-        warn "Skipping Pi extensions (pi not found on PATH)"
-    fi
-
-    announce "Pruning mise installs"
-    mise prune --yes
-    mise cache prune --yes
-
-    announce "Upgrading mise system packages"
-    if mise_system_available; then
-        MISE_EXPERIMENTAL=1 mise system install --yes --update || warn "Skipping mise system packages (mise system install failed)"
-    else
-        warn "Skipping mise system packages (unsupported by this mise version)"
-    fi
-
-    if command -v brew &> /dev/null; then
-        local brew_formulae=()
-        local formula
-
-        announce "Checking Homebrew metadata"
-        env HOMEBREW_AUTO_UPDATE_SECS="$HOMEBREW_AUTO_UPDATE_SECS" brew update-if-needed
-
-        while IFS= read -r formula; do
-            [ -n "$formula" ] && brew_formulae+=("$formula")
-        done < <(outdated_managed_brew_formulae)
-
-        if [ ${#brew_formulae[@]} -gt 0 ]; then
-            announce "Upgrading managed Homebrew formulae"
-            env HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade "${brew_formulae[@]}"
-
-            announce "Cleaning upgraded Homebrew formulae"
-            env HOMEBREW_NO_AUTO_UPDATE=1 brew cleanup "${brew_formulae[@]}"
-        else
-            warn "No managed Homebrew formulae need upgrades"
-        fi
-    elif is_debian; then
-        warn "Skipping Homebrew (brew not found on PATH)"
-    fi
-
-    debug "Upgrade complete"
-}
-
 report_mise_outdated() {
     announce "Checking mise tools"
     if ! command -v mise &> /dev/null; then
@@ -330,7 +204,7 @@ report_mise_outdated() {
     local output
     output="$(
         unset BUNDLE_GEMFILE BUNDLE_BIN_PATH RUBYOPT GEM_HOME GEM_PATH 2>/dev/null || true
-        mise outdated --json 2>/dev/null | ruby -rjson -e '
+        mise outdated --bump --json 2>/dev/null | ruby -rjson -e '
           begin
             tools = JSON.parse(STDIN.read)
           rescue JSON::ParserError
@@ -350,6 +224,53 @@ report_mise_outdated() {
         '
     )"
     if [[ "$output" == $'tool\tcurrent\tlatest'* ]]; then
+        printf '%s\n' "$output" | render_tsv_table
+    else
+        printf '%s\n' "$output"
+    fi
+}
+
+report_pi_package_outdated() {
+    announce "Checking Pi packages"
+
+    local settings_path="$DOTFILES_DIR/files/home/.pi/agent/settings.json"
+    if [ ! -f "$settings_path" ]; then
+        warn "Skipping Pi packages (settings not found)"
+        return 0
+    fi
+
+    if ! command -v mise &> /dev/null; then
+        warn "Skipping Pi packages (mise not found on PATH)"
+        return 0
+    fi
+
+    local output
+    output="$(
+        unset BUNDLE_GEMFILE BUNDLE_BIN_PATH RUBYOPT GEM_HOME GEM_PATH 2>/dev/null || true
+        ruby -rjson -e '
+          settings = JSON.parse(File.read(ARGV.fetch(0)))
+          settings.fetch("packages", []).grep(/^npm:/).each do |source|
+            match = source.match(/\Anpm:(.+)@([^@]+)\z/)
+            next unless match
+            puts [match[1], match[2]].join("\t")
+          end
+        ' "$settings_path" | while IFS=$'\t' read -r package current; do
+            latest="$(mise exec node@lts -- npm view "$package" version 2>/dev/null || true)"
+            [ -n "$latest" ] || continue
+            [ "$current" = "$latest" ] && continue
+            printf 'pi package\t%s\t%s\t%s\n' "$package" "$current" "$latest"
+        done | ruby -e '
+          rows = STDIN.read.lines.map(&:chomp).reject(&:empty?)
+          if rows.empty?
+            puts "Pi packages are up to date"
+          else
+            puts "manager\tpackage\tcurrent\tlatest"
+            puts rows
+          end
+        '
+    )"
+
+    if [[ "$output" == $'manager\tpackage\tcurrent\tlatest'* ]]; then
         printf '%s\n' "$output" | render_tsv_table
     else
         printf '%s\n' "$output"
@@ -406,7 +327,7 @@ write_outdated_pi_prompt() {
     cat > "$prompt_path" <<'EOF'
 Update the pinned package versions in this dotfiles repository to the latest versions allowed by configured constraints.
 
-Run `dotf outdated` first. Update files/home/.config/mise/config.toml and any other pinned package-manager files as needed, run the relevant tests, then open a GitHub PR.
+Run `dotf outdated` first. Update files/home/.config/mise/config.toml, files/home/.pi/agent/settings.json, and any other pinned package-manager files as needed, run the relevant tests, then open a GitHub PR.
 EOF
 
     warn "Wrote Pi upgrade prompt to $prompt_path"
@@ -425,6 +346,7 @@ cmd_outdated() {
     ensure_mise_env
 
     report_mise_outdated
+    report_pi_package_outdated
     if ! is_debian; then
         report_brew_outdated
     fi
@@ -479,7 +401,6 @@ Logging:
 
 Examples:
   dotf run                              # Initial setup
-  dotf upgrade                          # Upgrade mise tools, system packages, Pi extensions, and Homebrew apps
   dotf outdated                         # Show update candidates and write a Pi PR prompt
   dotf migrate                          # Run pending migrations on this machine
   DEBUG=true dotf run                   # Run with debug output to console
@@ -497,9 +418,6 @@ main() {
     case "$1" in
         run)
             cmd_run
-            ;;
-        upgrade)
-            cmd_upgrade
             ;;
         outdated)
             shift

--- a/lib/dotfiles/steps/clear_mise_cache_step.rb
+++ b/lib/dotfiles/steps/clear_mise_cache_step.rb
@@ -1,0 +1,63 @@
+class Dotfiles::Step::ClearMiseCacheStep < Dotfiles::Step
+  DESCRIPTION = "Clears mise metadata cache before installing managed tools.".freeze
+
+  def self.depends_on
+    [Dotfiles::Step::SyncHomeDirectoryStep]
+  end
+
+  def should_run?
+    mise_available? && !mise_offline? && install_needed?
+  end
+
+  def run
+    output, status = execute(clear_cache_command)
+    @error = format_command_error(clear_cache_command, status, output) unless status == 0
+  end
+
+  def complete?
+    super
+    add_error(@error) if @error
+    @errors.empty?
+  end
+
+  private
+
+  def install_needed?
+    return false unless managed_mise_config?
+
+    output, status = execute(install_check_command)
+    return true unless status == 0
+
+    output.to_s.lines.any? { |line| line.include?("would install") }
+  end
+
+  def managed_mise_config?
+    ci_tools.any? || @system.file_exist?(global_mise_config_path)
+  end
+
+  def ci_tools
+    ENV.fetch("MISE_CI_TOOLS", "").split(",").map(&:strip).reject(&:empty?)
+  end
+
+  def install_check_command
+    args = ["--cd", @home, "install", "--yes", "--dry-run"]
+    args.concat(ci_tools) unless ci_tools.empty?
+    command("mise", *args)
+  end
+
+  def clear_cache_command
+    command("mise", "cache", "clear", "--yes")
+  end
+
+  def global_mise_config_path
+    File.join(@home, ".config", "mise", "config.toml")
+  end
+
+  def mise_available?
+    command_exists?("mise")
+  end
+
+  def mise_offline?
+    ENV["MISE_OFFLINE"] == "1"
+  end
+end

--- a/lib/dotfiles/steps/install_mise_tools_step.rb
+++ b/lib/dotfiles/steps/install_mise_tools_step.rb
@@ -2,7 +2,7 @@ class Dotfiles::Step::InstallMiseToolsStep < Dotfiles::Step
   DESCRIPTION = "Installs tools defined in mise configuration for the current platform.".freeze
 
   def self.depends_on
-    [Dotfiles::Step::SyncHomeDirectoryStep]
+    [Dotfiles::Step::ClearMiseCacheStep]
   end
 
   def should_run?

--- a/lib/dotfiles/steps/install_pi_packages_step.rb
+++ b/lib/dotfiles/steps/install_pi_packages_step.rb
@@ -1,0 +1,75 @@
+require "json"
+
+class Dotfiles::Step::InstallPiPackagesStep < Dotfiles::Step
+  DESCRIPTION = "Installs Pi packages pinned in Pi settings.".freeze
+
+  def self.depends_on
+    [Dotfiles::Step::InstallMiseToolsStep]
+  end
+
+  def should_run?
+    pi_available? && missing_packages.any?
+  end
+
+  def run
+    @install_errors = []
+    missing_packages.each { |package| install_package(package) }
+  end
+
+  def complete?
+    super
+    return true unless settings_exist?
+    unless pi_available?
+      add_error("pi not available; cannot install Pi packages")
+      return false
+    end
+
+    install_errors.each { |message| add_error(message) }
+    missing_packages.each { |package| add_error("Pi package not installed: #{package}") }
+    @errors.empty?
+  end
+
+  private
+
+  def install_package(package)
+    output, status = execute(command("pi", "install", package))
+    install_errors << format_command_error(command("pi", "install", package), status, output) unless status == 0
+  end
+
+  def missing_packages
+    expected_packages.reject { |package| installed_packages.include?(package) }
+  end
+
+  def expected_packages
+    return [] unless settings_exist?
+
+    JSON.parse(@system.read_file(settings_path)).fetch("packages", [])
+  rescue JSON::ParserError
+    []
+  end
+
+  def installed_packages
+    return [] unless pi_available?
+
+    output, status = execute(command("pi", "list"))
+    return [] unless status == 0
+
+    output.lines.map(&:strip).grep(/^\S+$/)
+  end
+
+  def install_errors
+    @install_errors ||= []
+  end
+
+  def settings_exist?
+    @system.file_exist?(settings_path)
+  end
+
+  def settings_path
+    File.join(@home, ".pi", "agent", "settings.json")
+  end
+
+  def pi_available?
+    command_exists?("pi")
+  end
+end

--- a/lib/dotfiles/steps/mac/upgrade_brew_packages_step.rb
+++ b/lib/dotfiles/steps/mac/upgrade_brew_packages_step.rb
@@ -1,5 +1,5 @@
 class Dotfiles::Step::UpgradeBrewPackagesStep < Dotfiles::Step
-  DESCRIPTION = "Checks for outdated Homebrew packages and reports available upgrades.".freeze
+  DESCRIPTION = "Upgrades managed Homebrew packages that are already installed and outdated.".freeze
 
   macos_only
 
@@ -8,33 +8,45 @@ class Dotfiles::Step::UpgradeBrewPackagesStep < Dotfiles::Step
   end
 
   def should_run?
-    check_outdated_packages
-    false
+    outdated_managed_packages.any?
+  end
+
+  def run
+    @upgrade_error = nil
+    upgrade_outdated_packages
+    cleanup_upgraded_packages if @upgrade_error.nil?
   end
 
   def complete?
     super
-    true
+    add_error(@upgrade_error) if @upgrade_error
+    @errors.empty?
   end
 
   private
 
-  def check_outdated_packages
-    output, status = brew_quiet("outdated", "--formula", "--quiet")
-    debug("brew outdated --formula --quiet output: #{output.inspect}")
-    return unless status == 0
-
-    packages = managed_outdated_packages(output)
-    return if packages.empty?
-
-    add_notice(
-      title: "🍺 Homebrew Updates Available",
-      message: "#{packages.count} managed package(s) have updates available.\n\nRun 'brew upgrade #{packages.join(" ")}' to update them."
-    )
+  def upgrade_outdated_packages
+    output, status = brew_quiet("upgrade", *outdated_managed_packages)
+    @upgrade_error = format_command_error(brew_upgrade_command, status, output) unless status == 0
   end
 
-  def managed_outdated_packages(output)
-    outdated_packages = output.lines.map(&:strip).reject(&:empty?)
-    outdated_packages & @config.brew_packages
+  def cleanup_upgraded_packages
+    brew_quiet("cleanup", *outdated_managed_packages)
+  end
+
+  def outdated_managed_packages
+    @outdated_managed_packages ||= fetch_outdated_managed_packages
+  end
+
+  def fetch_outdated_managed_packages
+    output, status = brew_quiet("outdated", "--formula", "--quiet")
+    debug("brew outdated --formula --quiet output: #{output.inspect}")
+    return [] unless status == 0
+
+    output.lines.map(&:strip).reject(&:empty?) & @config.brew_packages
+  end
+
+  def brew_upgrade_command
+    env_command({"HOMEBREW_NO_AUTO_UPDATE" => "1", "HOMEBREW_NO_ENV_HINTS" => "1"}, "brew", "upgrade", *outdated_managed_packages)
   end
 end

--- a/lib/dotfiles/steps/prune_mise_step.rb
+++ b/lib/dotfiles/steps/prune_mise_step.rb
@@ -1,0 +1,66 @@
+class Dotfiles::Step::PruneMiseStep < Dotfiles::Step
+  DESCRIPTION = "Prunes old mise installs and cache entries after managed tools are installed.".freeze
+
+  def self.depends_on
+    [Dotfiles::Step::InstallMiseToolsStep, Dotfiles::Step::InstallPiPackagesStep]
+  end
+
+  def should_run?
+    mise_available? && !mise_offline? && ci_tools.empty? && prune_needed?
+  end
+
+  def run
+    @errors_from_commands = []
+    prune_commands.each { |prune_command| run_prune_command(prune_command) }
+  end
+
+  def complete?
+    super
+    errors_from_commands.each { |message| add_error(message) }
+    @errors.empty?
+  end
+
+  private
+
+  def prune_needed?
+    prunable_tools? || prunable_cache?
+  end
+
+  def prunable_tools?
+    _output, status = execute(command("mise", "prune", "--dry-run-code", "--yes"))
+    status != 0
+  end
+
+  def prunable_cache?
+    output, status = execute(command("mise", "cache", "prune", "--dry-run", "--verbose"))
+    status == 0 && !output.to_s.strip.empty?
+  end
+
+  def run_prune_command(prune_command)
+    output, status = execute(prune_command)
+    errors_from_commands << format_command_error(prune_command, status, output) unless status == 0
+  end
+
+  def prune_commands
+    [
+      command("mise", "prune", "--yes"),
+      command("mise", "cache", "prune", "--yes")
+    ]
+  end
+
+  def errors_from_commands
+    @errors_from_commands ||= []
+  end
+
+  def ci_tools
+    ENV.fetch("MISE_CI_TOOLS", "")
+  end
+
+  def mise_available?
+    command_exists?("mise")
+  end
+
+  def mise_offline?
+    ENV["MISE_OFFLINE"] == "1"
+  end
+end

--- a/test/dotfiles/dotf_cli_test.rb
+++ b/test/dotfiles/dotf_cli_test.rb
@@ -20,57 +20,21 @@ class DotfCliTest < Minitest::Test
     end
   end
 
-  def test_upgrade_updates_pi_extensions
-    assert_upgrade_commands(
-      stubs: %w[mise brew pi],
-      env: {
-        "DOTF_FORCE_NON_DEBIAN" => "true",
-        "DOTF_MANAGED_BREW_FORMULAE" => "duti,fish",
-        "DOTF_BREW_OUTDATED_FORMULAE" => "duti,unmanaged"
-      },
-      expected: [
-        "brew shellenv bash", "mise activate bash", "mise cache clear --yes", "mise plugins update",
-        "mise outdated --json",
-        "mise up --dry-run --before 3d --yes", "mise up --before 3d --yes",
-        "mise install --before 3d --yes", "pi update --extensions",
-        "mise prune --yes", "mise cache prune --yes", "MISE_EXPERIMENTAL=1 mise system install --help",
-        "MISE_EXPERIMENTAL=1 mise system install --yes --update",
-        "HOMEBREW_AUTO_UPDATE_SECS=604800 brew update-if-needed",
-        "HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --quiet",
-        "HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade duti",
-        "HOMEBREW_NO_AUTO_UPDATE=1 brew cleanup duti"
-      ]
-    )
+  def test_upgrade_command_is_removed
+    with_dotf_script do |_tmpdir, script_path, _logs_dir|
+      refute system("bash", script_path, "upgrade", out: File::NULL, err: File::NULL)
+    end
   end
 
-  def test_upgrade_skips_brew_upgrade_when_no_managed_formulae_are_outdated
-    assert_upgrade_commands(
-      stubs: %w[mise brew],
-      env: {
-        "DOTF_FORCE_NON_DEBIAN" => "true",
-        "DOTF_MANAGED_BREW_FORMULAE" => "duti",
-        "DOTF_BREW_OUTDATED_FORMULAE" => "unmanaged"
-      },
-      expected: [
-        "brew shellenv bash", "mise activate bash", "mise cache clear --yes", "mise plugins update",
-        "mise outdated --json",
-        "mise up --dry-run --before 3d --yes", "mise up --before 3d --yes",
-        "mise install --before 3d --yes", "mise prune --yes", "mise cache prune --yes",
-        "MISE_EXPERIMENTAL=1 mise system install --help",
-        "MISE_EXPERIMENTAL=1 mise system install --yes --update",
-        "HOMEBREW_AUTO_UPDATE_SECS=604800 brew update-if-needed",
-        "HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --quiet"
-      ]
-    )
-  end
-
-  def test_outdated_reports_mise_and_managed_homebrew_updates
+  def test_outdated_reports_mise_pi_and_managed_homebrew_updates
     with_dotf_script do |tmpdir, script_path, _logs_dir|
       bin_dir = File.join(tmpdir, "fake-bin")
       log_path = File.join(tmpdir, "outdated-commands.log")
       output_path = File.join(tmpdir, "outdated-output.log")
       FileUtils.mkdir_p(bin_dir)
       %w[mise brew].each { |command| write_command_stub(bin_dir, command) }
+      FileUtils.mkdir_p(File.join(tmpdir, "files", "home", ".pi", "agent"))
+      File.write(File.join(tmpdir, "files", "home", ".pi", "agent", "settings.json"), '{"packages":["npm:pi-ding@0.2.2"]}')
 
       brew_json = '{"formulae":[{"name":"duti","installed_versions":["1.0"],"current_version":"1.1"}],"casks":[{"token":"cursor","installed_versions":["2.0"],"current_version":"2.1"}]}'
       mise_json = '{"ruby":{"current":"4.0.5","latest":"4.0.6"}}'
@@ -80,6 +44,7 @@ class DotfCliTest < Minitest::Test
         "DOTF_MANAGED_BREW_CASKS" => "cursor",
         "DOTF_BREW_OUTDATED_JSON" => brew_json,
         "DOTF_MISE_OUTDATED_JSON" => mise_json,
+        "DOTF_NPM_LATEST" => "pi-ding=0.2.3",
         "DOTF_UPGRADE_LOG" => log_path,
         "PATH" => "#{bin_dir}:/usr/bin:/bin"
       }
@@ -92,30 +57,18 @@ class DotfCliTest < Minitest::Test
       assert_includes File.read(prompt_paths.first), "Update the pinned package versions"
 
       assert_equal [
-        "brew shellenv bash", "mise activate bash", "mise outdated --json",
+        "brew shellenv bash", "mise activate bash", "mise outdated --bump --json",
+        "mise exec node@lts -- npm view pi-ding version",
         "HOMEBREW_AUTO_UPDATE_SECS=604800 brew update-if-needed",
         "HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --json=v2"
       ], File.readlines(log_path, chomp: true)
       output = File.read(output_path)
       assert_includes output, "ruby\t4.0.5\t4.0.6"
+      assert_includes output, "pi package\tpi-ding\t0.2.2\t0.2.3"
       assert_includes output, "brew\tduti\t1.0\t1.1"
       assert_includes output, "brew cask\tcursor\t2.0\t2.1"
       assert_includes output, "You can run: pi"
     end
-  end
-
-  def test_upgrade_runs_on_debian_without_homebrew
-    assert_upgrade_commands(
-      stubs: %w[mise apt-get],
-      env: {"DOTF_FORCE_DEBIAN" => "true", "DOTF_SKIP_SUDO" => "true"},
-      expected: [
-        "mise activate bash", "mise cache clear --yes", "mise plugins update",
-        "mise outdated --json",
-        "mise up --dry-run --before 3d --yes", "mise up --before 3d --yes",
-        "mise install --before 3d --yes", "mise prune --yes", "mise cache prune --yes",
-        "MISE_EXPERIMENTAL=1 mise system install --help", "MISE_EXPERIMENTAL=1 mise system install --yes --update"
-      ]
-    )
   end
 
   def test_acquire_dotf_lock_blocks_second_live_holder
@@ -165,23 +118,6 @@ class DotfCliTest < Minitest::Test
   end
 
   private
-
-  def assert_upgrade_commands(stubs:, expected:, env: {})
-    with_dotf_script do |tmpdir, script_path, _logs_dir|
-      bin_dir = File.join(tmpdir, "fake-bin")
-      log_path = File.join(tmpdir, "upgrade-commands.log")
-      FileUtils.mkdir_p(bin_dir)
-      stubs.each { |command| write_command_stub(bin_dir, command) }
-
-      lock_dir = File.join(tmpdir, "dotf.lock")
-      with_env(env.merge("DOTF_UPGRADE_LOG" => log_path, "DOTF_LOCK_DIR" => lock_dir, "PATH" => "#{bin_dir}:/usr/bin:/bin")) do
-        clean_homebrew_env = {"HOMEBREW_AUTO_UPDATE_SECS" => nil, "HOMEBREW_NO_AUTO_UPDATE" => nil}
-        assert system(clean_homebrew_env, "bash", script_path, "upgrade", out: File::NULL)
-      end
-
-      assert_equal expected, File.readlines(log_path, chomp: true)
-    end
-  end
 
   def assert_last_thirty_logs_remain(logs_dir, removed: ["dotf_2000-01-01_00-00-00.log", "dotf_2000-01-01_00-00-01.log"])
     dotf_logs = current_dotf_logs(logs_dir)

--- a/test/dotfiles/steps/clear_mise_cache_step_test.rb
+++ b/test/dotfiles/steps/clear_mise_cache_step_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class ClearMiseCacheStepTest < StepTestCase
+  step_class Dotfiles::Step::ClearMiseCacheStep
+
+  def test_should_run_when_mise_install_would_install_tools
+    stub_managed_global_mise_config
+    stub_mise_available
+    stub_install_check("mise node@20.0.0                ⇢ would install\n")
+
+    assert_should_run
+  end
+
+  def test_should_not_run_when_mise_tools_are_installed
+    stub_managed_global_mise_config
+    stub_mise_available
+    stub_install_check("mise all tools are installed\n")
+
+    refute_should_run
+  end
+
+  def test_should_not_run_when_mise_is_missing
+    stub_mise_missing
+
+    refute_should_run
+  end
+
+  def test_should_not_run_when_offline
+    with_env("MISE_OFFLINE" => "1") do
+      stub_managed_global_mise_config
+      stub_mise_available
+      stub_install_check("mise node@20.0.0                ⇢ would install\n")
+
+      refute_should_run
+    end
+  end
+
+  def test_run_clears_mise_cache
+    @fake_system.stub_command("mise cache clear --yes", "")
+
+    step.run
+
+    assert_executed("mise cache clear --yes")
+  end
+
+  private
+
+  def stub_managed_global_mise_config
+    @fake_system.stub_file_content(File.join(@home, ".config", "mise", "config.toml"), "[tools]\nnode = \"lts\"\n")
+  end
+
+  def stub_mise_available
+    @fake_system.stub_command("command -v mise >/dev/null 2>&1", "", exit_status: 0)
+  end
+
+  def stub_mise_missing
+    @fake_system.stub_command("command -v mise >/dev/null 2>&1", "", exit_status: 1)
+  end
+
+  def stub_install_check(output)
+    @fake_system.stub_command("mise --cd #{@home} install --yes --dry-run", output, exit_status: 0)
+  end
+end

--- a/test/dotfiles/steps/install_pi_packages_step_test.rb
+++ b/test/dotfiles/steps/install_pi_packages_step_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class InstallPiPackagesStepTest < StepTestCase
+  step_class Dotfiles::Step::InstallPiPackagesStep
+
+  def test_should_not_run_by_default
+    refute_should_run
+  end
+
+  def test_should_run_when_pinned_package_is_missing
+    stub_settings('{"packages":["npm:pi-ding@0.2.2"]}')
+    stub_pi_available
+    stub_pi_list("")
+
+    assert_should_run
+  end
+
+  def test_should_not_run_when_pinned_package_is_installed
+    stub_settings('{"packages":["npm:pi-ding@0.2.2"]}')
+    stub_pi_available
+    stub_pi_list("User packages:\n  npm:pi-ding@0.2.2\n")
+
+    refute_should_run
+  end
+
+  def test_run_installs_missing_pinned_package
+    stub_settings('{"packages":["npm:pi-ding@0.2.2"]}')
+    stub_pi_available
+    stub_pi_list("")
+    @fake_system.stub_command("pi install npm:pi-ding@0.2.2", "")
+
+    step.run
+
+    assert_executed("pi install npm:pi-ding@0.2.2")
+  end
+
+  def test_complete_reports_missing_pi
+    stub_settings('{"packages":["npm:pi-ding@0.2.2"]}')
+    @fake_system.stub_command("command -v pi >/dev/null 2>&1", "", exit_status: 1)
+
+    assert_incomplete
+  end
+
+  private
+
+  def stub_settings(content)
+    @fake_system.stub_file_content(File.join(@home, ".pi", "agent", "settings.json"), content)
+  end
+
+  def stub_pi_available
+    @fake_system.stub_command("command -v pi >/dev/null 2>&1", "", exit_status: 0)
+  end
+
+  def stub_pi_list(output)
+    @fake_system.stub_command("pi list", output)
+  end
+end

--- a/test/dotfiles/steps/prune_mise_step_test.rb
+++ b/test/dotfiles/steps/prune_mise_step_test.rb
@@ -1,0 +1,86 @@
+require "test_helper"
+
+class PruneMiseStepTest < StepTestCase
+  step_class Dotfiles::Step::PruneMiseStep
+
+  def test_should_run_when_mise_tools_are_prunable
+    stub_mise_available
+    stub_prunable_tools
+
+    assert_should_run
+  end
+
+  def test_should_run_when_mise_cache_is_prunable
+    stub_mise_available
+    stub_no_prunable_tools
+    stub_prunable_cache
+
+    assert_should_run
+  end
+
+  def test_should_not_run_when_nothing_is_prunable
+    stub_mise_available
+    stub_no_prunable_tools
+    stub_no_prunable_cache
+
+    refute_should_run
+  end
+
+  def test_should_not_run_when_mise_is_missing
+    stub_mise_missing
+
+    refute_should_run
+  end
+
+  def test_should_not_run_with_ci_tools
+    with_env("MISE_CI_TOOLS" => "fzf@latest") do
+      stub_mise_available
+
+      refute_should_run
+    end
+  end
+
+  def test_should_not_run_when_offline
+    with_env("MISE_OFFLINE" => "1") do
+      stub_mise_available
+
+      refute_should_run
+    end
+  end
+
+  def test_run_prunes_mise_installs_and_cache
+    @fake_system.stub_command("mise prune --yes", "")
+    @fake_system.stub_command("mise cache prune --yes", "")
+
+    step.run
+
+    assert_executed("mise prune --yes")
+    assert_executed("mise cache prune --yes")
+  end
+
+  private
+
+  def stub_mise_available
+    @fake_system.stub_command("command -v mise >/dev/null 2>&1", "", exit_status: 0)
+  end
+
+  def stub_mise_missing
+    @fake_system.stub_command("command -v mise >/dev/null 2>&1", "", exit_status: 1)
+  end
+
+  def stub_prunable_tools
+    @fake_system.stub_command("mise prune --dry-run-code --yes", "rm old-tool", exit_status: 1)
+  end
+
+  def stub_no_prunable_tools
+    @fake_system.stub_command("mise prune --dry-run-code --yes", "", exit_status: 0)
+  end
+
+  def stub_prunable_cache
+    @fake_system.stub_command("mise cache prune --dry-run --verbose", "rm cache-file")
+  end
+
+  def stub_no_prunable_cache
+    @fake_system.stub_command("mise cache prune --dry-run --verbose", "")
+  end
+end

--- a/test/dotfiles/steps/upgrade_brew_packages_step_test.rb
+++ b/test/dotfiles/steps/upgrade_brew_packages_step_test.rb
@@ -2,55 +2,61 @@ require "test_helper"
 
 class UpgradeBrewPackagesStepTest < Minitest::Test
   include ConfigFixtureHelper
+  include SystemAssertions
 
   def test_complete_returns_true
     step = create_step(Dotfiles::Step::UpgradeBrewPackagesStep)
     assert step.complete?
   end
 
-  def test_adds_notice_for_outdated_managed_packages
+  def test_should_run_for_outdated_managed_packages
     write_config("config", "packages" => {"fish" => {"brew" => "fish"}, "gh" => {"brew" => "gh"}})
     step = create_step(Dotfiles::Step::UpgradeBrewPackagesStep)
     @fake_system.stub_command(brew_outdated_command, "bat\nfish\ngh\n")
 
-    step.should_run?
-
-    assert_brew_update_notice(step, "2 managed package(s)", "brew upgrade fish gh")
+    assert step.should_run?
   end
 
-  def test_no_notice_when_only_unmanaged_packages_are_outdated
+  def test_should_not_run_when_only_unmanaged_packages_are_outdated
     write_config("config", "packages" => {"fish" => {"brew" => "fish"}})
     step = create_step(Dotfiles::Step::UpgradeBrewPackagesStep)
     @fake_system.stub_command(brew_outdated_command, "bat\n")
 
-    step.should_run?
-
-    assert_empty step.notices
+    refute step.should_run?
   end
 
-  def test_no_notice_when_packages_up_to_date
-    step = create_step(Dotfiles::Step::UpgradeBrewPackagesStep)
-    @fake_system.stub_command(brew_outdated_command, "")
-
-    step.should_run?
-
-    assert_empty step.notices
-  end
-
-  def test_should_run_returns_false
+  def test_should_not_run_when_packages_up_to_date
     step = create_step(Dotfiles::Step::UpgradeBrewPackagesStep)
     @fake_system.stub_command(brew_outdated_command, "")
 
     refute step.should_run?
   end
 
-  def test_no_notice_when_brew_outdated_fails
+  def test_run_upgrades_and_cleans_outdated_managed_packages
+    write_config("config", "packages" => {"fish" => {"brew" => "fish"}, "gh" => {"brew" => "gh"}})
     step = create_step(Dotfiles::Step::UpgradeBrewPackagesStep)
-    @fake_system.stub_command(brew_outdated_command, "Warning: Homebrew had a problem\nTry again later", exit_status: 1)
+    @fake_system.stub_command(brew_outdated_command, "bat\nfish\ngh\n")
+    @fake_system.stub_command(brew_upgrade_command("fish", "gh"), "")
+    @fake_system.stub_command(brew_cleanup_command("fish", "gh"), "")
 
     step.should_run?
+    step.run
 
-    assert_empty step.notices
+    assert_executed(brew_upgrade_command("fish", "gh"))
+    assert_executed(brew_cleanup_command("fish", "gh"))
+  end
+
+  def test_complete_reports_upgrade_failure
+    write_config("config", "packages" => {"fish" => {"brew" => "fish"}})
+    step = create_step(Dotfiles::Step::UpgradeBrewPackagesStep)
+    @fake_system.stub_command(brew_outdated_command, "fish\n")
+    @fake_system.stub_command(brew_upgrade_command("fish"), "boom", exit_status: 1)
+
+    step.should_run?
+    step.run
+
+    refute step.complete?
+    assert_includes step.errors.join("\n"), "brew upgrade fish failed"
   end
 
   def test_uses_quiet_homebrew_environment
@@ -64,15 +70,19 @@ class UpgradeBrewPackagesStepTest < Minitest::Test
 
   private
 
-  def assert_brew_update_notice(step, count_message, upgrade_command)
-    assert_equal 1, step.notices.size
-    notice = step.notices.first
-    assert_includes notice[:title], "Homebrew Updates Available"
-    assert_includes notice[:message], count_message
-    assert_includes notice[:message], upgrade_command
+  def brew_outdated_command
+    brew_command("outdated", "--formula", "--quiet")
   end
 
-  def brew_outdated_command
-    [{"HOMEBREW_NO_AUTO_UPDATE" => "1", "HOMEBREW_NO_ENV_HINTS" => "1"}, "brew", "outdated", "--formula", "--quiet"]
+  def brew_upgrade_command(*packages)
+    brew_command("upgrade", *packages)
+  end
+
+  def brew_cleanup_command(*packages)
+    brew_command("cleanup", *packages)
+  end
+
+  def brew_command(*args)
+    [{"HOMEBREW_NO_AUTO_UPDATE" => "1", "HOMEBREW_NO_ENV_HINTS" => "1"}, "brew", *args]
   end
 end

--- a/test/support/dotf_script_helper.rb
+++ b/test/support/dotf_script_helper.rb
@@ -50,12 +50,16 @@ module DotfScriptHelper
           printf '%s\n' '{"formulae":[],"casks":[]}'
         fi
       fi
-      if [ "#{command}" = "mise" ] && [ "$*" = "outdated --json" ]; then
+      if [ "#{command}" = "mise" ] && { [ "$*" = "outdated --json" ] || [ "$*" = "outdated --bump --json" ]; }; then
         if [ -n "${DOTF_MISE_OUTDATED_JSON+x}" ]; then
           printf '%s\n' "$DOTF_MISE_OUTDATED_JSON"
         else
           printf '%s\n' '{}'
         fi
+      fi
+      if [ "#{command}" = "mise" ] && [ "${1:-}" = "exec" ] && [ "${2:-}" = "node@lts" ] && [ "${3:-}" = "--" ] && [ "${4:-}" = "npm" ] && [ "${5:-}" = "view" ] && [ "${7:-}" = "version" ]; then
+        package="$6"
+        printf '%s\n' "${DOTF_NPM_LATEST:-}" | tr ',' '\n' | awk -F= -v package="$package" '$1 == package { print $2 }'
       fi
     BASH
     FileUtils.chmod("+x", path)


### PR DESCRIPTION
## Summary
- remove the mutating `dotf upgrade` command
- make `dotf outdated` report mise pin bumps and pinned Pi package updates
- move machine convergence into `dotf run`: pinned Pi package installs, managed Homebrew formula upgrades, and mise cache/prune maintenance steps

## Tests
- bundle exec rake test
- bundle exec standardrb