### PR TITLE
Improve dotf outdated upgrade prompts

### DIFF
--- a/bin/dotf
+++ b/bin/dotf
@@ -210,16 +210,24 @@ report_mise_outdated() {
           rescue JSON::ParserError
             tools = {}
           end
-          if tools.empty?
+          rows = []
+          tools.each do |name, tool|
+            current = tool["current"].to_s
+            latest = tool["latest"].to_s
+            next if current.empty? || latest.empty? || current == latest
+            rows << [name, current, latest]
+          end
+
+          if rows.empty?
             puts "mise tools are up to date"
           else
-            puts "tool\tcurrent\tlatest"
-            tools.each do |name, tool|
-              current = tool["current"].to_s
-              latest = tool["latest"].to_s
-              next if current.empty? || latest.empty? || current == latest
-              puts "#{name}\t#{current}\t#{latest}"
+            if ENV["DOTF_OUTDATED_ROWS_PATH"]
+              File.open(ENV.fetch("DOTF_OUTDATED_ROWS_PATH"), "a") do |file|
+                rows.each { |row| file.puts((["mise"] + row).join("\t")) }
+              end
             end
+            puts "tool\tcurrent\tlatest"
+            rows.each { |row| puts row.join("\t") }
           end
         '
     )"
@@ -255,15 +263,42 @@ report_pi_package_outdated() {
             puts [match[1], match[2]].join("\t")
           end
         ' "$settings_path" | while IFS=$'\t' read -r package current; do
-            latest="$(mise exec node@lts -- npm view "$package" version 2>/dev/null || true)"
+            latest="$(
+                unset BUNDLE_GEMFILE BUNDLE_BIN_PATH RUBYOPT GEM_HOME GEM_PATH 2>/dev/null || true
+                mise exec node@lts -- npm view "$package" time versions --json 2>/dev/null | env DOTF_CURRENT_VERSION="$current" ruby -rjson -rtime -e '
+                  begin
+                    data = JSON.parse(STDIN.read)
+                  rescue JSON::ParserError
+                    data = {}
+                  end
+
+                  current = ENV.fetch("DOTF_CURRENT_VERSION")
+                  cutoff = Time.now - (3 * 24 * 60 * 60)
+                  versions = Array(data["versions"])
+                  times = data.fetch("time", {})
+                  latest = versions.reverse.find do |version|
+                    published_at = times[version]
+                    published_at && Time.parse(published_at) <= cutoff
+                  rescue ArgumentError
+                    false
+                  end
+                  current_index = versions.index(current)
+                  latest_index = versions.index(latest)
+                  puts latest if latest && (!current_index || !latest_index || latest_index > current_index)
+                '
+            )"
             [ -n "$latest" ] || continue
-            [ "$current" = "$latest" ] && continue
             printf 'pi package\t%s\t%s\t%s\n' "$package" "$current" "$latest"
         done | ruby -e '
           rows = STDIN.read.lines.map(&:chomp).reject(&:empty?)
           if rows.empty?
             puts "Pi packages are up to date"
           else
+            if ENV["DOTF_OUTDATED_ROWS_PATH"]
+              File.open(ENV.fetch("DOTF_OUTDATED_ROWS_PATH"), "a") do |file|
+                rows.each { |row| file.puts(row) }
+              end
+            end
             puts "manager\tpackage\tcurrent\tlatest"
             puts rows
           end
@@ -307,6 +342,11 @@ report_brew_outdated() {
           if rows.empty?
             puts "Homebrew packages are up to date"
           else
+            if ENV["DOTF_OUTDATED_ROWS_PATH"]
+              File.open(ENV.fetch("DOTF_OUTDATED_ROWS_PATH"), "a") do |file|
+                rows.each { |row| file.puts(row.join("\t")) }
+              end
+            end
             puts "manager\tpackage\tcurrent\tlatest"
             rows.each { |row| puts row.join("\t") }
           end
@@ -324,11 +364,33 @@ write_outdated_pi_prompt() {
     local prompt_path="$prompt_dir/pi-upgrade-prompt-$(dotf_date '%Y-%m-%d_%H-%M-%S').md"
 
     mkdir -p "$prompt_dir"
-    cat > "$prompt_path" <<'EOF'
-Update the pinned package versions in this dotfiles repository to the latest versions allowed by configured constraints.
+    (
+        unset BUNDLE_GEMFILE BUNDLE_BIN_PATH RUBYOPT GEM_HOME GEM_PATH 2>/dev/null || true
+        ruby -e '
+          rows = if ENV["DOTF_OUTDATED_ROWS_PATH"] && File.exist?(ENV.fetch("DOTF_OUTDATED_ROWS_PATH"))
+            File.readlines(ENV.fetch("DOTF_OUTDATED_ROWS_PATH"), chomp: true).reject(&:empty?)
+          else
+            []
+          end
 
-Run `dotf outdated` first. Update files/home/.config/mise/config.toml, files/home/.pi/agent/settings.json, and any other pinned package-manager files as needed, run the relevant tests, then open a GitHub PR.
-EOF
+          puts "Update the pinned package versions in this dotfiles repository to the latest versions allowed by configured constraints."
+          puts
+          if rows.empty?
+            puts "No managed package updates were found by this dotf outdated run."
+          else
+            puts "Upgrade these managed packages:"
+            puts
+            puts "| Manager | Package | Current | Latest |"
+            puts "| --- | --- | --- | --- |"
+            rows.each do |row|
+              manager, package, current, latest = row.split("\t", 4)
+              puts "| #{manager} | #{package} | #{current} | #{latest} |"
+            end
+          end
+          puts
+          puts "Update files/home/.config/mise/config.toml, files/home/.pi/agent/settings.json, and any other pinned package-manager files as needed, run the relevant tests, then open a GitHub PR."
+        '
+    ) > "$prompt_path"
 
     warn "Wrote Pi upgrade prompt to $prompt_path"
     warn "You can run: pi \"\$(cat \"$prompt_path\")\""
@@ -345,6 +407,11 @@ cmd_outdated() {
     is_debian || ensure_homebrew_env
     ensure_mise_env
 
+    mkdir -p "$DOTFILES_DIR/tmp"
+    local outdated_rows_path="$DOTFILES_DIR/tmp/outdated-updates-$$.tsv"
+    : > "$outdated_rows_path"
+    export DOTF_OUTDATED_ROWS_PATH="$outdated_rows_path"
+
     report_mise_outdated
     report_pi_package_outdated
     if ! is_debian; then
@@ -352,6 +419,8 @@ cmd_outdated() {
     fi
 
     write_outdated_pi_prompt
+    rm -f "$outdated_rows_path"
+    unset DOTF_OUTDATED_ROWS_PATH
 
     debug "Outdated check complete"
 }

--- a/test/dotfiles/dotf_cli_test.rb
+++ b/test/dotfiles/dotf_cli_test.rb
@@ -38,13 +38,14 @@ class DotfCliTest < Minitest::Test
 
       brew_json = '{"formulae":[{"name":"duti","installed_versions":["1.0"],"current_version":"1.1"}],"casks":[{"token":"cursor","installed_versions":["2.0"],"current_version":"2.1"}]}'
       mise_json = '{"ruby":{"current":"4.0.5","latest":"4.0.6"}}'
+      npm_json = '{"versions":["0.2.2","0.2.3","0.2.4"],"time":{"0.2.2":"2000-01-01T00:00:00.000Z","0.2.3":"2000-01-02T00:00:00.000Z","0.2.4":"2999-01-01T00:00:00.000Z"}}'
       env = {
         "DOTF_FORCE_NON_DEBIAN" => "true",
         "DOTF_MANAGED_BREW_FORMULAE" => "duti",
         "DOTF_MANAGED_BREW_CASKS" => "cursor",
         "DOTF_BREW_OUTDATED_JSON" => brew_json,
         "DOTF_MISE_OUTDATED_JSON" => mise_json,
-        "DOTF_NPM_LATEST" => "pi-ding=0.2.3",
+        "DOTF_NPM_VIEW_JSON" => npm_json,
         "DOTF_UPGRADE_LOG" => log_path,
         "PATH" => "#{bin_dir}:/usr/bin:/bin"
       }
@@ -54,17 +55,24 @@ class DotfCliTest < Minitest::Test
 
       prompt_paths = Dir.glob(File.join(tmpdir, "tmp", "pi-upgrade-prompt-*.md"))
       assert_equal 1, prompt_paths.size
-      assert_includes File.read(prompt_paths.first), "Update the pinned package versions"
+      prompt = File.read(prompt_paths.first)
+      assert_includes prompt, "Update the pinned package versions"
+      assert_includes prompt, "| mise | ruby | 4.0.5 | 4.0.6 |"
+      assert_includes prompt, "| pi package | pi-ding | 0.2.2 | 0.2.3 |"
+      assert_includes prompt, "| brew | duti | 1.0 | 1.1 |"
+      assert_includes prompt, "| brew cask | cursor | 2.0 | 2.1 |"
+      refute_includes prompt, "Run `dotf outdated` first"
 
       assert_equal [
         "brew shellenv bash", "mise activate bash", "mise outdated --bump --json",
-        "mise exec node@lts -- npm view pi-ding version",
+        "mise exec node@lts -- npm view pi-ding time versions --json",
         "HOMEBREW_AUTO_UPDATE_SECS=604800 brew update-if-needed",
         "HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --json=v2"
       ], File.readlines(log_path, chomp: true)
       output = File.read(output_path)
       assert_includes output, "ruby\t4.0.5\t4.0.6"
       assert_includes output, "pi package\tpi-ding\t0.2.2\t0.2.3"
+      refute_includes output, "0.2.4"
       assert_includes output, "brew\tduti\t1.0\t1.1"
       assert_includes output, "brew cask\tcursor\t2.0\t2.1"
       assert_includes output, "You can run: pi"

--- a/test/support/dotf_script_helper.rb
+++ b/test/support/dotf_script_helper.rb
@@ -57,9 +57,14 @@ module DotfScriptHelper
           printf '%s\n' '{}'
         fi
       fi
-      if [ "#{command}" = "mise" ] && [ "${1:-}" = "exec" ] && [ "${2:-}" = "node@lts" ] && [ "${3:-}" = "--" ] && [ "${4:-}" = "npm" ] && [ "${5:-}" = "view" ] && [ "${7:-}" = "version" ]; then
-        package="$6"
-        printf '%s\n' "${DOTF_NPM_LATEST:-}" | tr ',' '\n' | awk -F= -v package="$package" '$1 == package { print $2 }'
+      if [ "#{command}" = "mise" ] && [ "${1:-}" = "exec" ] && [ "${2:-}" = "node@lts" ] && [ "${3:-}" = "--" ] && [ "${4:-}" = "npm" ] && [ "${5:-}" = "view" ] && [ "${7:-}" = "time" ] && [ "${8:-}" = "versions" ] && [ "${9:-}" = "--json" ]; then
+        if [ -n "${DOTF_NPM_VIEW_JSON+x}" ]; then
+          printf '%s\n' "$DOTF_NPM_VIEW_JSON"
+        else
+          package="$6"
+          version="$(printf '%s\n' "${DOTF_NPM_LATEST:-}" | tr ',' '\n' | awk -F= -v package="$package" '$1 == package { print $2 }')"
+          printf '{"versions":["%s"],"time":{"%s":"2000-01-01T00:00:00.000Z"}}\n' "$version" "$version"
+        fi
       fi
     BASH
     FileUtils.chmod("+x", path)


### PR DESCRIPTION
## Summary
- include the concrete manager/package/current/latest table in generated Pi upgrade prompts
- keep Pi package upgrade candidates on versions published at least 3 days ago
- cover the prompt and 3-day npm selection behavior in dotf CLI tests

## Tests
- bundle exec ruby -Itest test/dotfiles/dotf_cli_test.rb
- bundle exec rake test
- pre-commit hook via git commit