### PR TITLE
Update pinned package versions

### DIFF
--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -104,7 +104,7 @@ jobs:
         CI: true
         NONINTERACTIVE: true
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "fzf@latest,aqua:fish-shell/fish-shell@4.7.1"
+        MISE_CI_TOOLS: "fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_TAPS: ""
         BREW_CI_CASKS: ""
@@ -205,7 +205,7 @@ jobs:
         CI: true
         NONINTERACTIVE: true
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "fzf@latest,aqua:fish-shell/fish-shell@4.7.1"
+        MISE_CI_TOOLS: "fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_TAPS: ""
         BREW_CI_CASKS: ""

--- a/.mise.toml
+++ b/.mise.toml
@@ -7,7 +7,7 @@ BUNDLE_PATH = "vendor/bundle"
 dfr = "./bin/dotf run"
 
 [tools]
-hk = "1.49.0"
+hk = "1.51.0"
 
 [deps.bundler]
 auto = true

--- a/files/home/.config/mise/config.toml
+++ b/files/home/.config/mise/config.toml
@@ -1,30 +1,30 @@
 # Managed by dotfiles. This file is the source of truth for machine-wide mise tools.
 [tools]
-ruby = "4.0.5"
-node = "24.18.0"
-"github:jdx/aube" = "1.25.2"
+ruby = "4.0.6"
+node = "26.5.0"
+"github:jdx/aube" = "1.28.0"
 go = "1.26.4"
 rust = "1.96.1"
-hk = "1.49.0"
+hk = "1.51.0"
 "cargo:broot" = "1.57.0"
 "cargo:difftastic" = "0.69.0"
 "cargo:starship" = "1.26.0"
 "gem:try-cli" = "1.9.3"
-"npm:@openai/codex" = { version = "0.142.5", depends = ["github:jdx/aube"] }
+"npm:@openai/codex" = { version = "0.144.5", depends = ["github:jdx/aube"] }
 "npm:sfw" = { version = "2.0.6", depends = ["github:jdx/aube"] }
-"npm:@earendil-works/pi-coding-agent" = { version = "0.78.0", depends = ["github:jdx/aube"], minimum_release_age = "0d", aube_args = "--deny-build=@google/genai --deny-build=protobufjs" }
+"npm:@earendil-works/pi-coding-agent" = { version = "0.80.9", depends = ["github:jdx/aube"], minimum_release_age = "0d", aube_args = "--deny-build=@google/genai --deny-build=protobufjs" }
 "go:github.com/mikefarah/yq/v4" = "4.53.3"
 "go:github.com/noperator/yknotify" = "0.0.0-20260324103239-0c773bdadedb"
 "github:aldanial/cloc" = "2.08"
 "github:pkgforge-dev/ghostty-appimage[bin=ghostty]" = { version = "1.3.1", os = ["linux"] }
 "github:nateberkopec/print-label" = "0.1.2"
 watchexec = "2.5.1"
-fnox = "1.28.0"
+fnox = "1.30.0"
 bat = "0.26.1"
 cmake = "4.3.3"
 fd = "10.4.2"
 fzf = "0.73.1"
-"aqua:fish-shell/fish-shell" = "4.7.1"
+"aqua:fish-shell/fish-shell" = "4.8.1"
 gh = "2.96.0"
 git-lfs = "3.7.1"
 gum = "0.17.0"
@@ -35,14 +35,14 @@ shellcheck = "0.11.0"
 tmux = "3.7b"
 zoxide = "0.10.0"
 pkl = "0.31.1"
-claude = "2.1.201"
+claude = "2.1.211"
 gitleaks = "8.30.1"
-"1password-cli" = "2.34.0"
-acli = "1.3.18-stable"
-heroku = { version = "11.4.0", depends = ["github:jdx/aube"] }
-"aqua:planetscale/cli" = "0.285.0"
+"1password-cli" = "2.35.0"
+acli = "1.3.22-stable"
+heroku = { version = "11.8.1", depends = ["github:jdx/aube"] }
+"aqua:planetscale/cli" = "0.303.0"
 "github:rawnly/splash-cli" = "4.1.7"
-"github:fabro-sh/fabro" = "0.246.0-nightly.0"
+"github:fabro-sh/fabro" = "0.254.0"
 
 [settings]
 env_shell_expand = false

--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -5,10 +5,10 @@
   "defaultThinkingLevel": "medium",
   "hideThinkingBlock": false,
   "packages": [
-    "npm:pi-mcp-adapter@2.8.0",
+    "npm:pi-mcp-adapter@2.11.0",
     "npm:pi-ding@0.2.2",
-    "npm:pi-subagents@0.25.0",
-    "npm:pi-web-providers@3.2.0"
+    "npm:pi-subagents@0.34.0",
+    "npm:pi-web-providers@3.5.0"
   ],
   "npmCommand": [
     "mise",

--- a/lib/dotfiles/migrations/202605310001_migrate_brew_taps_to_mise.rb
+++ b/lib/dotfiles/migrations/202605310001_migrate_brew_taps_to_mise.rb
@@ -2,12 +2,12 @@ class Dotfiles::Migration::MigrateBrewTapsToMise < Dotfiles::Migration
   VERSION = 202605310001
 
   MISE_TOOLS = [
-    "1password-cli@2.34.0",
-    "acli@1.3.18-stable",
-    "heroku@11.4.0",
-    "aqua:planetscale/cli@0.285.0",
+    "1password-cli@2.35.0",
+    "acli@1.3.22-stable",
+    "heroku@11.8.1",
+    "aqua:planetscale/cli@0.303.0",
     "github:rawnly/splash-cli@4.1.7",
-    "github:fabro-sh/fabro@0.246.0-nightly.0"
+    "github:fabro-sh/fabro@0.254.0"
   ].freeze
 
   BREW_FORMULAE = %w[

--- a/test/dotfiles/steps/set_fish_default_shell_step_test.rb
+++ b/test/dotfiles/steps/set_fish_default_shell_step_test.rb
@@ -93,7 +93,7 @@ class SetFishDefaultShellStepTest < Minitest::Test
   end
 
   def test_prefers_mise_managed_fish
-    fish = File.join(@home, ".local", "share", "mise", "installs", "aqua-fish-shell-fish-shell", "4.7.1", "fish.pkg", "Payload", "usr", "local", "bin", "fish")
+    fish = File.join(@home, ".local", "share", "mise", "installs", "aqua-fish-shell-fish-shell", "4.8.1", "fish.pkg", "Payload", "usr", "local", "bin", "fish")
     @fake_system.stub_file_content(fish, "binary")
     @fake_system.stub_file_content("/opt/homebrew/bin/fish", "binary")
     @fake_system.stub_command(["dscl", ".", "-read", @home, "UserShell"], "UserShell: #{fish}")


### PR DESCRIPTION
## Summary
- update managed mise tool pins to the requested latest versions
- update pi package pins in agent settings
- keep migration/CI fish version references aligned with the managed pins

Homebrew casks are listed token-only in the repo Brewfile/config, so there were no cask version pins to edit.

## Tests
- bundle exec rake test
- bundle exec standardrb
- ruby tools/lint_agent_skills.rb
- pre-commit hook ran full test/lint suite during commit