### PR TITLE
Update pi enabled models and reconcile settings

### DIFF
--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -1,7 +1,7 @@
 {
-  "lastChangelogVersion": "0.62.0",
+  "lastChangelogVersion": "0.80.9",
   "defaultProvider": "openai-codex",
-  "defaultModel": "gpt-5.5",
+  "defaultModel": "gpt-5.6-sol",
   "defaultThinkingLevel": "medium",
   "hideThinkingBlock": false,
   "packages": [
@@ -23,8 +23,10 @@
     "path": "/System/Library/Sounds/Glass.aiff"
   },
   "enabledModels": [
-    "openai-codex/gpt-5.5",
-    "openai-codex/gpt-5.4-mini:xhigh"
+    "openai-codex/gpt-5.6-sol:medium",
+    "openai-codex/gpt-5.6-terra:xhigh",
+    "x-ai/grok-4.5",
+    "fireworks/glm-5p2-priority"
   ],
   "subagents": {
     "agentOverrides": {
@@ -38,6 +40,9 @@
     "enabled": true,
     "maxRetries": 5,
     "baseDelayMs": 2000,
-    "maxDelayMs": 30000
-  }
+    "provider": {
+      "maxRetryDelayMs": 30000
+    }
+  },
+  "theme": "dark"
 }


### PR DESCRIPTION
## What

Updates `files/home/.pi/agent/settings.json`:

**Model changes**
- **Default model** → `openai-codex` / `gpt-5.6-sol` / `medium` (GPT-5.6 Sol)
- **Enabled model scope** now:
  - `openai-codex/gpt-5.6-sol:medium`
  - `openai-codex/gpt-5.6-terra:xhigh`
  - `x-ai/grok-4.5` (via openrouter)
  - `fireworks/glm-5p2-priority` (custom model from `models.json`)

**Reconcile source with live `~/.pi`**

pi writes to the live file directly, and `dotf run` copies dotfiles source → home, so these pi-written fields were getting reverted on every sync. Adopted the live values into source:
- `lastChangelogVersion`: `0.62.0` → `0.80.9`
- `retry`: flat `maxDelayMs` → nested `provider.maxRetryDelayMs` (0.80.9 schema)
- added `theme: dark`

## Why

The prior enabled models (`gpt-5.5`, `gpt-5.4-mini`) and default (`gpt-5.5`) were stale, and the source file had drifted from what pi actually uses. After this, source and live are byte-identical, so the next `dotf run` is a no-op for this file.

## Verification

- Both model IDs verified against pi's live catalog (`pi-ai` provider defs); `medium`/`xhigh` confirmed valid via `getSupportedThinkingLevels`.
- JSON validated; source/live divergences: none.
- Pre-commit lints + tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)