### PR TITLE
Fix Pi package version reconciliation

### DIFF
--- a/lib/dotfiles/steps/install_pi_packages_step.rb
+++ b/lib/dotfiles/steps/install_pi_packages_step.rb
@@ -4,7 +4,7 @@ class Dotfiles::Step::InstallPiPackagesStep < Dotfiles::Step
   DESCRIPTION = "Installs Pi packages pinned in Pi settings.".freeze
 
   def self.depends_on
-    [Dotfiles::Step::InstallMiseToolsStep]
+    [Dotfiles::Step::InstallMiseToolsStep, Dotfiles::Step::SyncHomeDirectoryStep]
   end
 
   def should_run?
@@ -37,7 +37,23 @@ class Dotfiles::Step::InstallPiPackagesStep < Dotfiles::Step
   end
 
   def missing_packages
-    expected_packages.reject { |package| installed_packages.include?(package) }
+    expected_packages.reject { |package| package_installed?(package) }
+  end
+
+  def package_installed?(package)
+    npm_package = package.match(/\Anpm:(.+)@([^@]+)\z/)
+    return installed_packages.include?(package) unless npm_package
+
+    installed_npm_version(npm_package[1]) == npm_package[2]
+  end
+
+  def installed_npm_version(package)
+    path = File.join(@home, ".pi", "agent", "npm", "node_modules", package, "package.json")
+    return unless @system.file_exist?(path)
+
+    JSON.parse(@system.read_file(path))["version"]
+  rescue JSON::ParserError
+    nil
   end
 
   def expected_packages

--- a/test/dotfiles/steps/install_pi_packages_step_test.rb
+++ b/test/dotfiles/steps/install_pi_packages_step_test.rb
@@ -3,6 +3,13 @@ require "test_helper"
 class InstallPiPackagesStepTest < StepTestCase
   step_class Dotfiles::Step::InstallPiPackagesStep
 
+  def test_depends_on_mise_tools_and_home_directory_sync
+    assert_equal [
+      Dotfiles::Step::InstallMiseToolsStep,
+      Dotfiles::Step::SyncHomeDirectoryStep
+    ], self.class.step_class.depends_on
+  end
+
   def test_should_not_run_by_default
     refute_should_run
   end
@@ -18,9 +25,18 @@ class InstallPiPackagesStepTest < StepTestCase
   def test_should_not_run_when_pinned_package_is_installed
     stub_settings('{"packages":["npm:pi-ding@0.2.2"]}')
     stub_pi_available
-    stub_pi_list("User packages:\n  npm:pi-ding@0.2.2\n")
+    stub_installed_npm_package("pi-ding", "0.2.2")
 
     refute_should_run
+  end
+
+  def test_should_run_when_installed_npm_package_does_not_match_pin
+    stub_settings('{"packages":["npm:pi-subagents@0.34.0"]}')
+    stub_pi_available
+    stub_pi_list("User packages:\n  npm:pi-subagents@0.34.0\n")
+    stub_installed_npm_package("pi-subagents", "0.25.0")
+
+    assert_should_run
   end
 
   def test_run_installs_missing_pinned_package
@@ -53,5 +69,10 @@ class InstallPiPackagesStepTest < StepTestCase
 
   def stub_pi_list(output)
     @fake_system.stub_command("pi list", output)
+  end
+
+  def stub_installed_npm_package(name, version)
+    path = File.join(@home, ".pi", "agent", "npm", "node_modules", name, "package.json")
+    @fake_system.stub_file_content(path, JSON.generate("version" => version))
   end
 end


### PR DESCRIPTION
## Summary

- verify pinned npm Pi package versions from their installed `package.json` files instead of trusting `pi list`
- run Pi package reconciliation after tracked home settings have synced
- add regression coverage for configured pins masking stale installed versions

## Root cause

`pi list` reports package specs from `settings.json`, not versions present in `node_modules`. After dotfiles synced newer pins, the installer mistook those configured versions for installed versions and skipped `pi install`.

## Testing

- `bundle exec rake test` (460 runs, 846 assertions)
- `bundle exec standardrb lib/dotfiles/steps/install_pi_packages_step.rb test/dotfiles/steps/install_pi_packages_step_test.rb`
- complexity, flog, and flay checks passed
