### PR TITLE
Allow Heroku installation with Aube

### DIFF
--- a/files/home/.config/mise/config.toml
+++ b/files/home/.config/mise/config.toml
@@ -39,7 +39,7 @@ claude = "2.1.211"
 gitleaks = "8.30.1"
 "1password-cli" = "2.35.0"
 acli = "1.3.22-stable"
-heroku = { version = "11.8.1", depends = ["github:jdx/aube"] }
+heroku = { version = "11.8.1", depends = ["github:jdx/aube"], aube_args = "--deny-build=cpu-features --deny-build=protobufjs --deny-build=ssh2 --deny-build=yarn" }
 "aqua:planetscale/cli" = "0.303.0"
 "github:rawnly/splash-cli" = "4.1.7"
 "github:fabro-sh/fabro" = "0.254.0"


### PR DESCRIPTION
## Summary

- explicitly deny the four nonessential lifecycle builds in Heroku’s dependency tree
- preserve Aube’s strict dependency-build policy instead of allowing every build script
- allow mise to complete the Heroku installation through Aube

The denied scripts only build optional SSH optimizations, print a protobuf compatibility warning, or handle a global Yarn/Corepack conflict. Heroku remains functional without them.

## Verification

- installed `heroku@11.8.1` with Aube using this exact denial policy
- `heroku --version`
- `heroku help`
- `heroku plugins --help`
- `mise run test`
- `mise run lint`