### PR TITLE
Update pinned package versions

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -7,7 +7,7 @@ BUNDLE_PATH = "vendor/bundle"
 dfr = "./bin/dotf run"
 
 [tools]
-hk = "1.51.0"
+hk = "1.53.0"
 
 [deps.bundler]
 auto = true

--- a/files/home/.config/mise/config.toml
+++ b/files/home/.config/mise/config.toml
@@ -2,20 +2,20 @@
 [tools]
 ruby = "4.0.6"
 node = "26.5.0"
-"github:jdx/aube" = "1.28.0"
+"github:jdx/aube" = "1.32.0"
 go = "1.26.4"
 rust = "1.96.1"
-hk = "1.51.0"
+hk = "1.53.0"
 "cargo:broot" = "1.57.0"
 "cargo:difftastic" = "0.69.0"
 "cargo:starship" = "1.26.0"
 "gem:try-cli" = "1.9.3"
-"npm:@openai/codex" = { version = "0.144.5", depends = ["github:jdx/aube"] }
+"npm:@openai/codex" = { version = "0.145.0", depends = ["github:jdx/aube"] }
 "npm:sfw" = { version = "2.0.6", depends = ["github:jdx/aube"] }
-"npm:@earendil-works/pi-coding-agent" = { version = "0.80.9", depends = ["github:jdx/aube"], minimum_release_age = "0d", aube_args = "--deny-build=@google/genai --deny-build=protobufjs" }
+"npm:@earendil-works/pi-coding-agent" = { version = "0.82.1", depends = ["github:jdx/aube"], minimum_release_age = "0d", aube_args = "--deny-build=@google/genai --deny-build=protobufjs" }
 "go:github.com/mikefarah/yq/v4" = "4.53.3"
 "go:github.com/noperator/yknotify" = "0.0.0-20260324103239-0c773bdadedb"
-"github:aldanial/cloc" = "2.08"
+"github:aldanial/cloc" = "2.10"
 "github:pkgforge-dev/ghostty-appimage[bin=ghostty]" = { version = "1.3.1", os = ["linux"] }
 "github:nateberkopec/print-label" = "0.1.2"
 watchexec = "2.5.1"
@@ -35,12 +35,12 @@ shellcheck = "0.11.0"
 tmux = "3.7b"
 zoxide = "0.10.0"
 pkl = "0.31.1"
-claude = "2.1.211"
+claude = "2.1.219"
 gitleaks = "8.30.1"
 "1password-cli" = "2.35.0"
 acli = "1.3.22-stable"
 heroku = { version = "11.8.1", depends = ["github:jdx/aube"], aube_args = "--deny-build=cpu-features --deny-build=protobufjs --deny-build=ssh2 --deny-build=yarn" }
-"aqua:planetscale/cli" = "0.303.0"
+"aqua:planetscale/cli" = "0.307.0"
 "github:rawnly/splash-cli" = "4.1.7"
 "github:fabro-sh/fabro" = "0.254.0"
 

--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -5,10 +5,10 @@
   "defaultThinkingLevel": "medium",
   "hideThinkingBlock": false,
   "packages": [
-    "npm:pi-mcp-adapter@2.11.0",
+    "npm:pi-mcp-adapter@2.12.1",
     "npm:pi-ding@0.2.2",
-    "npm:pi-subagents@0.34.0",
-    "npm:pi-web-providers@3.5.0"
+    "npm:pi-subagents@0.36.0",
+    "npm:pi-web-providers@3.5.1"
   ],
   "npmCommand": [
     "mise",

--- a/lib/dotfiles/migrations/202605310001_migrate_brew_taps_to_mise.rb
+++ b/lib/dotfiles/migrations/202605310001_migrate_brew_taps_to_mise.rb
@@ -5,7 +5,7 @@ class Dotfiles::Migration::MigrateBrewTapsToMise < Dotfiles::Migration
     "1password-cli@2.35.0",
     "acli@1.3.22-stable",
     "heroku@11.8.1",
-    "aqua:planetscale/cli@0.303.0",
+    "aqua:planetscale/cli@0.307.0",
     "github:rawnly/splash-cli@4.1.7",
     "github:fabro-sh/fabro@0.254.0"
   ].freeze


### PR DESCRIPTION
## Summary
- update the requested mise-managed tools to their latest allowed versions
- update pinned Pi packages
- keep the repository hk pin and PlanetScale migration pin aligned with the managed mise config

## Tests
- `bundle exec rake test`
- `bundle exec standardrb lib/dotfiles/migrations/202605310001_migrate_brew_taps_to_mise.rb`
- `bundle exec rubocop --config .rubocop-custom.yml --only Metrics/PerceivedComplexity lib/dotfiles/migrations/202605310001_migrate_brew_taps_to_mise.rb`
- pre-commit checks (standard, complexity, large-files, human-only, secrets, dead-code, flog, flay, skills, full test suite)
