### PR TITLE
Add mise platform templates

### DIFF
--- a/files/templates/ghostty-config.platform
+++ b/files/templates/ghostty-config.platform
@@ -1,0 +1,5 @@
+{% if os() == "macos" -%}
+font-size = 18
+{%- else -%}
+font-size = 14
+{%- endif %}

--- a/files/templates/ghostty-config.platform
+++ b/files/templates/ghostty-config.platform
@@ -1,5 +1,1 @@
-{% if os() == "macos" -%}
 font-size = 18
-{%- else -%}
-font-size = 14
-{%- endif %}

--- a/files/templates/platform.fish
+++ b/files/templates/platform.fish
@@ -1,0 +1,34 @@
+{% if os() == "macos" -%}
+if status is-interactive
+  if test -d /opt/homebrew
+    set -gx HOMEBREW_PREFIX /opt/homebrew
+    set -gx HOMEBREW_CELLAR /opt/homebrew/Cellar
+    set -gx HOMEBREW_REPOSITORY /opt/homebrew
+    fish_add_path -g -m /opt/homebrew/bin /opt/homebrew/sbin
+
+    if test -x /opt/workbrew/bin/brew
+      fish_add_path -g -m /opt/workbrew/bin
+    end
+
+    if test -d /opt/homebrew/share/info
+      contains /opt/homebrew/share/info $INFOPATH; or set -gx INFOPATH /opt/homebrew/share/info $INFOPATH
+    end
+  end
+end
+
+if test -d /opt/homebrew/opt/libpq/bin
+  fish_add_path /opt/homebrew/opt/libpq/bin
+end
+
+set -x MAKEFLAGS -j(sysctl -n hw.ncpu)
+
+if test -f /opt/homebrew/bin/mosh-server
+  alias mosh-mbp "mosh --server='SHELL=/opt/homebrew/bin/fish /opt/homebrew/bin/mosh-server' nateberkopec@MBP-Server.local"
+end
+
+if test -f ~/.orbstack/shell/init2.fish
+  source ~/.orbstack/shell/init2.fish 2>/dev/null || :
+end
+{%- else -%}
+set -x MAKEFLAGS -j(nproc)
+{%- endif %}


### PR DESCRIPTION
## What

Adds dormant mise templates for platform-specific Fish configuration and Ghostty configuration. The rendered Fish output matches the current platform overlays; Ghostty now uses font size 18 on every platform.

The existing overlays remain in place and nothing references these templates yet.

## Testing

- Rendered macOS and Linux Fish variants and compared them with current overlays
- Verified the Ghostty template has no platform fork and uses font size 18
- `fish -n` on both rendered Fish files
- `mise run lint`
- Remaining 475 Ruby tests pass; the full local suite has the same two environment-sensitive `FlogFlayTasksTest` failures on unchanged `origin/main`

## Review size

35 text lines changed.

Refs #462
Umbrella: #463
