### PR TITLE
Seed mise bootstrap config from repository

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -3,6 +3,7 @@
 set -e
 
 BOOTSTRAP_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOTFILES_ROOT="$(dirname "$BOOTSTRAP_DIR")"
 # shellcheck source=lib/dotf-common.sh
 source "$BOOTSTRAP_DIR/lib/dotf-common.sh"
 
@@ -157,6 +158,8 @@ bootstrap_mise() {
         debug "mise already installed"
     fi
 
+    seed_global_mise_config
+
     # Trust mise config in current directory (needed for non-interactive environments)
     if [ -f ".mise.toml" ]; then
         debug "Trusting mise config..."
@@ -169,6 +172,12 @@ bootstrap_mise() {
 
     configure_mise_ruby_precompiled
     eval "$(mise activate bash)"
+}
+
+seed_global_mise_config() {
+    debug "Seeding global mise config from the repo..."
+    mkdir -p "$HOME/.config/mise"
+    cp "$DOTFILES_ROOT/files/home/.config/mise/config.toml" "$HOME/.config/mise/config.toml"
 }
 
 configure_mise_ruby_precompiled() {

--- a/test/bootstrap_test.rb
+++ b/test/bootstrap_test.rb
@@ -47,6 +47,20 @@ class BootstrapTest < Minitest::Test
     end
   end
 
+  def test_bootstrap_mise_seeds_global_config_before_activation
+    with_bootstrap_stub do |env|
+      global_config = File.join(env.fetch("HOME"), ".config", "mise", "config.toml")
+      FileUtils.mkdir_p(File.dirname(global_config))
+      File.write(global_config, "stale config\n")
+      write_mise_stub(env)
+
+      run_bootstrap_mise(env)
+
+      expected = File.read(File.expand_path("../files/home/.config/mise/config.toml", __dir__))
+      assert_equal expected, File.read(env.fetch("MISE_CONFIG_AT_ACTIVATION_LOG"))
+    end
+  end
+
   def test_mise_ruby_compile_workaround_expires
     assert Date.today < MISE_RUBY_COMPILE_WORKAROUND_REMOVE_BY,
       "Remove bootstrap's ruby.compile workaround; mise 2026.8.0 should make this default."

--- a/test/support/bootstrap_script_helper.rb
+++ b/test/support/bootstrap_script_helper.rb
@@ -22,7 +22,8 @@ module BootstrapScriptHelper
       "HOMEBREW_INSTALL_ENV_LOG" => File.join(tmpdir, "homebrew-install-env"),
       "HOMEBREW_INSTALLED_BREW" => File.join(home_dir, ".installed-homebrew", "bin", "brew"),
       "HOMEBREW_CONFIGURED_BREW_LOG" => File.join(tmpdir, "configured-brew"),
-      "MISE_COMMAND_LOG" => File.join(tmpdir, "mise-commands")
+      "MISE_COMMAND_LOG" => File.join(tmpdir, "mise-commands"),
+      "MISE_CONFIG_AT_ACTIVATION_LOG" => File.join(tmpdir, "mise-config-at-activation")
     }
   end
 
@@ -44,6 +45,9 @@ module BootstrapScriptHelper
     File.write(File.join(bin_dir, "mise"), <<~'BASH')
       #!/bin/bash
       printf '%s\n' "mise $*" >> "$MISE_COMMAND_LOG"
+      if [ "$*" = "activate bash" ]; then
+        cat "$HOME/.config/mise/config.toml" > "$MISE_CONFIG_AT_ACTIVATION_LOG"
+      fi
     BASH
     FileUtils.chmod("+x", File.join(bin_dir, "mise"))
   end


### PR DESCRIPTION
## What

Seeds `~/.config/mise/config.toml` from the repository during `bin/bootstrap`, before mise activation. The focused bootstrap test verifies that stale global config is replaced before `mise activate bash` reads it.

This is a prerequisite extracted from #463; it does not invoke `mise bootstrap` or remove the existing Ruby/gum bootstrap path.

## Testing

- `bundle exec ruby -Itest test/bootstrap_test.rb` (6 runs, 24 assertions)
- `bash -n bin/bootstrap`
- ShellCheck, excluding two pre-existing informational findings in `bin/bootstrap`
- `mise run lint`
- Full local suite has the same two environment-sensitive `FlogFlayTasksTest` failures on unchanged `origin/main`

## Review size

29 text lines changed.

Refs #462
Umbrella: #463
