### PR TITLE
Add mise dotfiles hook scripts

### DIFF
--- a/bin/lib/post-dotfiles-hook.sh
+++ b/bin/lib/post-dotfiles-hook.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Post-dotfiles hook for `mise bootstrap` (see [bootstrap.hooks] in
+# files/home/.config/mise/config.toml). Links fish completions that ship
+# inside OrbStack's app bundle — a conditional source mise's [dotfiles]
+# entries can't express (they abort when a source is missing).
+
+set -e
+
+[ "$(uname -s)" = "Darwin" ] || exit 0
+
+orbstack_completions="/Applications/OrbStack.app/Contents/Resources/completions/fish"
+[ -d "$orbstack_completions" ] || exit 0
+
+mkdir -p "$HOME/.config/fish/completions"
+for name in docker kubectl orbctl; do
+    source_path="$orbstack_completions/$name.fish"
+    [ -e "$source_path" ] || continue
+    ln -sfn "$source_path" "$HOME/.config/fish/completions/$name.fish"
+done

--- a/bin/lib/unprotect-managed-files.sh
+++ b/bin/lib/unprotect-managed-files.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Pre-dotfiles hook for `mise bootstrap` (see [bootstrap.hooks] in
+# files/home/.config/mise/config.toml). The Protect Files / Protect Git Hooks
+# steps mark some managed files immutable; strip the flags only when the repo
+# copy differs so mise's dotfiles phase can overwrite them. The protect steps
+# re-apply the flags afterwards.
+
+set -e
+
+[ "$(uname -s)" = "Darwin" ] || exit 0
+
+DOTFILES_HOME="$HOME/.dotfiles/files/home"
+
+managed_protected_files=(
+    ".aws/credentials"
+    ".gem/credentials"
+    ".git-hooks/pre-commit"
+    ".git-hooks/pre-push"
+    ".pi/agent/extensions/find_timeout.ts"
+)
+
+for relative in "${managed_protected_files[@]}"; do
+    target="$HOME/$relative"
+    source="$DOTFILES_HOME/$relative"
+    [ -f "$target" ] && [ -f "$source" ] || continue
+    cmp -s "$target" "$source" && continue
+
+    chflags nouchg "$target" 2>/dev/null ||
+        sudo chflags noschg,nouchg "$target"
+done


### PR DESCRIPTION
## What

Adds two dormant scripts for the future mise dotfiles phase:

- lift immutable flags from changed managed files before copying
- recreate OrbStack fish completion links when OrbStack is present

The immutable list covers every file protected by the existing Protect Files and Protect Git Hooks steps, including AWS credentials. Nothing references these hooks yet.

## Testing

- `bash -n` and ShellCheck for both scripts
- macOS/Linux behavior smoke tests
- `mise run lint`
- Full local suite has the same two environment-sensitive `FlogFlayTasksTest` failures on unchanged `origin/main`

## Review size

51 text lines changed.

Refs #462
Umbrella: #463
