### PR TITLE
Add mise defaults hook scripts

### DIFF
--- a/bin/lib/post-defaults-hook.sh
+++ b/bin/lib/post-defaults-hook.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Post-defaults hook for `mise bootstrap` (see [bootstrap.hooks] in
+# files/home/.config/mise/config.toml). Writes defaults mise can't express
+# declaratively (values needing $HOME expansion) and relaunches the apps that
+# read changed defaults.
+
+set -e
+
+[ "$(uname -s)" = "Darwin" ] || exit 0
+
+drift_marker="${TMPDIR:-/tmp}/dotf-defaults-changed-$(id -u)"
+restart_ui=false
+
+screenshot_location="$HOME/Documents/Inbox"
+if [ "$(defaults read com.apple.screencapture location 2>/dev/null)" != "$screenshot_location" ]; then
+    defaults write com.apple.screencapture location "$screenshot_location"
+    restart_ui=true
+fi
+
+if [ -f "$drift_marker" ]; then
+    rm -f "$drift_marker"
+    killall Dock 2>/dev/null || true
+    killall Finder 2>/dev/null || true
+    restart_ui=true
+fi
+
+if [ "$restart_ui" = true ]; then
+    killall SystemUIServer 2>/dev/null || true
+fi

--- a/bin/lib/pre-defaults-hook.sh
+++ b/bin/lib/pre-defaults-hook.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Pre-defaults hook for `mise bootstrap` (see [bootstrap.hooks] in
+# files/home/.config/mise/config.toml). Marks drift before the defaults phase
+# runs so the post-defaults hook can relaunch affected apps only when
+# something actually changed.
+
+set -e
+
+[ "$(uname -s)" = "Darwin" ] || exit 0
+
+drift_marker="${TMPDIR:-/tmp}/dotf-defaults-changed-$(id -u)"
+
+if ! mise bootstrap macos defaults status --missing >/dev/null 2>&1; then
+    touch "$drift_marker"
+fi


### PR DESCRIPTION
## What

Adds dormant pre/post scripts for the future mise macOS-defaults phase. They detect defaults drift, write the HOME-dependent screenshot location, and restart affected UI processes only when needed.

The drift marker is UID-qualified to avoid cross-user interference. Nothing references these hooks yet.

## Testing

- `bash -n` and ShellCheck for both scripts
- isolated drift/no-drift behavior smoke tests
- `mise run lint`
- Full local suite has the same two environment-sensitive `FlogFlayTasksTest` failures on unchanged `origin/main`

## Review size

46 text lines changed.

Refs #462
Umbrella: #463
