### PR TITLE
Prepare Debian package sources during bootstrap

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -126,6 +126,35 @@ bootstrap_homebrew() {
     configure_homebrew_shellenv "$brew_bin"
 }
 
+ensure_debian_apt_source() {
+    local name="$1"
+    local key_url="$2"
+    local source_line="$3"
+    local keyring_dir="${DEBIAN_KEYRING_DIR:-/usr/share/keyrings}"
+    local source_dir="${DEBIAN_SOURCE_DIR:-/etc/apt/sources.list.d}"
+    local keyring_path="$keyring_dir/${name}-archive-keyring.gpg"
+    local source_path="$source_dir/${name}.list"
+
+    if [ ! -f "$keyring_path" ]; then
+        local key_file
+        key_file="$(mktemp)"
+        curl -fsSL "$key_url" -o "$key_file"
+        sudo gpg --dearmor -o "$keyring_path" "$key_file"
+        rm -f "$key_file"
+    fi
+
+    if ! grep -Fxq "$source_line" "$source_path" 2>/dev/null; then
+        printf '%s\n' "$source_line" | sudo tee "$source_path" >/dev/null
+    fi
+}
+
+prepare_debian_apt_sources() {
+    ensure_debian_apt_source "gierens" "https://raw.githubusercontent.com/eza-community/eza/main/deb.asc" \
+        "deb [signed-by=/usr/share/keyrings/gierens-archive-keyring.gpg] http://deb.gierens.de stable main"
+    ensure_debian_apt_source "mise" "https://mise.jdx.dev/gpg-key.pub" \
+        "deb [signed-by=/usr/share/keyrings/mise-archive-keyring.gpg] https://mise.jdx.dev/deb stable main"
+}
+
 bootstrap_debian_prereqs() {
     if ! is_linux; then
         return 0
@@ -140,6 +169,7 @@ bootstrap_debian_prereqs() {
         gnupg \
         unzip \
         xz-utils
+    prepare_debian_apt_sources
 }
 
 bootstrap_mise() {

--- a/test/bootstrap_test.rb
+++ b/test/bootstrap_test.rb
@@ -37,6 +37,37 @@ class BootstrapTest < Minitest::Test
     end
   end
 
+  def test_prepare_debian_apt_sources_installs_missing_keys_and_sources
+    with_bootstrap_stub do |env|
+      run_prepare_debian_apt_sources(env)
+
+      expected_urls = [
+        "https://raw.githubusercontent.com/eza-community/eza/main/deb.asc",
+        "https://mise.jdx.dev/gpg-key.pub"
+      ]
+      assert_equal expected_urls, File.readlines(env.fetch("APT_CURL_LOG"), chomp: true)
+      %w[gierens mise].each do |name|
+        assert File.exist?(File.join(env.fetch("DEBIAN_KEYRING_DIR"), "#{name}-archive-keyring.gpg"))
+        assert_equal apt_source_line(name) + "\n", File.read(File.join(env.fetch("DEBIAN_SOURCE_DIR"), "#{name}.list"))
+      end
+    end
+  end
+
+  def test_prepare_debian_apt_sources_preserves_existing_keys_and_sources
+    with_bootstrap_stub do |env|
+      FileUtils.mkdir_p([env.fetch("DEBIAN_KEYRING_DIR"), env.fetch("DEBIAN_SOURCE_DIR")])
+      %w[gierens mise].each do |name|
+        File.write(File.join(env.fetch("DEBIAN_KEYRING_DIR"), "#{name}-archive-keyring.gpg"), "existing")
+        File.write(File.join(env.fetch("DEBIAN_SOURCE_DIR"), "#{name}.list"), apt_source_line(name) + "\n")
+      end
+
+      run_prepare_debian_apt_sources(env)
+
+      refute File.exist?(env.fetch("APT_CURL_LOG"))
+      refute File.exist?(env.fetch("APT_SUDO_LOG"))
+    end
+  end
+
   def test_bootstrap_mise_sets_ruby_compile_false
     with_bootstrap_stub do |env|
       write_mise_stub(env)
@@ -67,6 +98,11 @@ class BootstrapTest < Minitest::Test
   end
 
   private
+
+  def apt_source_line(name)
+    repo = (name == "gierens") ? "http://deb.gierens.de" : "https://mise.jdx.dev/deb"
+    "deb [signed-by=/usr/share/keyrings/#{name}-archive-keyring.gpg] #{repo} stable main"
+  end
 
   def homebrew_installer_scenarios
     [

--- a/test/support/bootstrap_script_helper.rb
+++ b/test/support/bootstrap_script_helper.rb
@@ -23,7 +23,11 @@ module BootstrapScriptHelper
       "HOMEBREW_INSTALLED_BREW" => File.join(home_dir, ".installed-homebrew", "bin", "brew"),
       "HOMEBREW_CONFIGURED_BREW_LOG" => File.join(tmpdir, "configured-brew"),
       "MISE_COMMAND_LOG" => File.join(tmpdir, "mise-commands"),
-      "MISE_CONFIG_AT_ACTIVATION_LOG" => File.join(tmpdir, "mise-config-at-activation")
+      "MISE_CONFIG_AT_ACTIVATION_LOG" => File.join(tmpdir, "mise-config-at-activation"),
+      "DEBIAN_KEYRING_DIR" => File.join(tmpdir, "keyrings"),
+      "DEBIAN_SOURCE_DIR" => File.join(tmpdir, "sources"),
+      "APT_CURL_LOG" => File.join(tmpdir, "apt-curl"),
+      "APT_SUDO_LOG" => File.join(tmpdir, "apt-sudo")
     }
   end
 
@@ -72,6 +76,16 @@ module BootstrapScriptHelper
 
   def run_bootstrap_mise(env)
     run_bootstrap_commands(env, nil, "bootstrap_mise")
+  end
+
+  def run_prepare_debian_apt_sources(env)
+    FileUtils.mkdir_p([env.fetch("DEBIAN_KEYRING_DIR"), env.fetch("DEBIAN_SOURCE_DIR")])
+    run_bootstrap_commands(env, nil, <<~'BASH')
+      sudo() { printf '%s\n' "$*" >> "$APT_SUDO_LOG"; "$@"; }
+      curl() { printf '%s\n' "$2" >> "$APT_CURL_LOG"; printf 'key' > "$4"; }
+      gpg() { cp "$4" "$3"; }
+      prepare_debian_apt_sources
+    BASH
   end
 
   def run_bootstrap_commands(env, terminal, script, no_terminal: false)


### PR DESCRIPTION
## What

Prepares the gierens/eza and mise APT keyrings and source lists during Debian bootstrap prerequisites. Existing exact sources and keyrings are left untouched, so repeated runs are idempotent.

These sources support the already-declared future mise APT packages. macOS behavior is unchanged.

## Testing

- `bundle exec ruby -Itest test/bootstrap_test.rb` — 8 runs, 33 assertions
- Missing and existing key/source scenarios
- `bash -n bin/bootstrap`
- ShellCheck
- `mise run lint`

## Review size

82 text lines changed.

Refs #462
Umbrella: #463
