### PR TITLE
Add CI mise config trimmer

### DIFF
--- a/test/trim_mise_config_test.rb
+++ b/test/trim_mise_config_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+require "toml-rb"
+
+# standard:disable Dotfiles/BanFileSystemClasses
+class TrimMiseConfigTest < Minitest::Test
+  def test_trims_ci_managed_tables_and_removes_launchd
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "config.toml")
+      File.write(path, <<~TOML)
+        [tools]
+        ruby = "4.0.6"
+        node = "26.5.0"
+
+        [bootstrap.packages]
+        "brew:git" = "latest"
+        "apt:curl" = "latest"
+
+        [bootstrap.macos.launchd.agents.yknotify]
+        program = "yknotify"
+
+        [settings]
+        experimental = true
+      TOML
+      env = {
+        "MISE_CI_TOOLS" => "ruby@4.0.6, gh",
+        "BREW_CI_PACKAGES" => "ba\"sh",
+        "DEBIAN_CI_PACKAGES" => "curl"
+      }
+      assert system(env, RbConfig.ruby, script_path, path)
+
+      rendered = File.read(path)
+      TomlRB.parse(rendered)
+      assert_includes rendered, "\"ruby\" = \"4.0.6\""
+      assert_includes rendered, "\"gh\" = \"latest\""
+      assert_includes rendered, "\"brew:ba\\\"sh\" = \"latest\""
+      assert_includes rendered, "\"apt:curl\" = \"latest\""
+      assert_includes rendered, "experimental = true"
+      refute_includes rendered, "node ="
+      refute_includes rendered, "launchd"
+    end
+  end
+
+  private
+
+  def script_path
+    File.expand_path("../tools/ci/trim_mise_config.rb", __dir__)
+  end
+end
+# standard:enable Dotfiles/BanFileSystemClasses

--- a/tools/ci/trim_mise_config.rb
+++ b/tools/ci/trim_mise_config.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+require "json"
+
+CONFIG_PATH = File.expand_path("../../files/home/.config/mise/config.toml", __dir__)
+
+def csv(name)
+  ENV.fetch(name, "").split(",").map(&:strip).reject(&:empty?)
+end
+
+def toml_string(value)
+  JSON.generate(value)
+end
+
+def replace_table(content, header, entries)
+  active = false
+  content.lines.each_with_object([]) do |line, output|
+    if line.lstrip.start_with?("[")
+      active = line.strip == header
+      if active
+        output.concat(["#{header}\n", *entries.map { |entry| "#{entry}\n" }, "\n"]) if entries
+      else
+        output << line
+      end
+    elsif !active || line.lstrip.start_with?("#")
+      output << line
+    end
+  end.join
+end
+
+def tool_entries
+  csv("MISE_CI_TOOLS").map do |spec|
+    name, separator, version = spec.rpartition("@")
+    name, version = spec, "latest" if separator.empty?
+    %(#{toml_string(name)} = #{toml_string(version)})
+  end
+end
+
+def package_entries
+  csv("BREW_CI_PACKAGES").map { |name| %(#{toml_string("brew:#{name}")} = "latest") } +
+    csv("DEBIAN_CI_PACKAGES").map { |name| %(#{toml_string("apt:#{name}")} = "latest") }
+end
+
+path = ARGV.fetch(0, CONFIG_PATH)
+content = File.read(path)
+content = replace_table(content, "[tools]", tool_entries) if ENV.key?("MISE_CI_TOOLS")
+if ENV.key?("BREW_CI_PACKAGES") || ENV.key?("DEBIAN_CI_PACKAGES")
+  content = replace_table(content, "[bootstrap.packages]", package_entries)
+end
+content = replace_table(content, "[bootstrap.macos.launchd.agents.yknotify]", nil)
+File.write(path, content)


### PR DESCRIPTION
## What

Adds an unwired CI helper that trims the repository mise config to the small tool and package sets integration CI requests through its existing environment variables. It also removes the unsupported yknotify launchd table when present.

Other tables and comments are preserved. Environment-provided TOML strings are escaped, and the output is parsed in the focused test.

## Testing

- `bundle exec ruby -Itest test/trim_mise_config_test.rb` — 1 run, 15 assertions
- Embedded-quote escaping and TOML parsing
- `ruby -c tools/ci/trim_mise_config.rb`
- `mise run lint`

## Review size

99 text lines changed.

Refs #462
Umbrella: #463
