### PR TITLE
Scope mise package managers by platform

### DIFF
--- a/bin/dotf
+++ b/bin/dotf
@@ -107,6 +107,12 @@ ensure_homebrew_env() {
 }
 
 ensure_mise_env() {
+    if is_debian; then
+        export MISE_SYSTEM_PACKAGES_MANAGERS=apt
+    else
+        export MISE_SYSTEM_PACKAGES_MANAGERS=brew
+    fi
+
     if [ -d "$HOME/.local/bin" ]; then
         export PATH="$HOME/.local/bin:$PATH"
     fi

--- a/test/dotfiles/dotf_cli_test.rb
+++ b/test/dotfiles/dotf_cli_test.rb
@@ -26,6 +26,18 @@ class DotfCliTest < Minitest::Test
     end
   end
 
+  def test_mise_uses_apt_for_system_packages_on_debian
+    with_dotf_script do |_tmpdir, script_path, _logs_dir|
+      assert_equal "apt", mise_system_packages_manager(script_path, "DOTF_FORCE_DEBIAN")
+    end
+  end
+
+  def test_mise_uses_brew_for_system_packages_elsewhere
+    with_dotf_script do |_tmpdir, script_path, _logs_dir|
+      assert_equal "brew", mise_system_packages_manager(script_path, "DOTF_FORCE_NON_DEBIAN")
+    end
+  end
+
   def test_outdated_reports_mise_pi_and_managed_homebrew_updates
     with_dotf_script do |tmpdir, script_path, _logs_dir|
       bin_dir = File.join(tmpdir, "fake-bin")
@@ -126,6 +138,11 @@ class DotfCliTest < Minitest::Test
   end
 
   private
+
+  def mise_system_packages_manager(script_path, platform_override)
+    command = "source #{Shellwords.escape(script_path)}; ensure_mise_env; printf %s \"$MISE_SYSTEM_PACKAGES_MANAGERS\""
+    IO.popen({platform_override => "true", "PATH" => "/usr/bin:/bin"}, ["bash", "-c", command], &:read)
+  end
 
   def assert_last_thirty_logs_remain(logs_dir, removed: ["dotf_2000-01-01_00-00-00.log", "dotf_2000-01-01_00-00-01.log"])
     dotf_logs = current_dotf_logs(logs_dir)


### PR DESCRIPTION
## What

Scopes mise's system-package backend to `apt` on Debian and `brew` elsewhere before activating mise. This prevents mise's brew backend from being selected on Linux when the package phase is activated later.

The current `dotf run` path still does not invoke `mise bootstrap`.

## Testing

- `bundle exec ruby -Itest test/dotfiles/dotf_cli_test.rb` — 9 runs, 57 assertions
- Debian and non-Debian environment assertions
- `bash -n bin/dotf`
- ShellCheck
- `mise run lint`

## Review size

23 text lines changed.

Refs #462
Umbrella: #463
