### PR TITLE
Link bootstrap checkout at standard path

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -98,6 +98,16 @@ has_terminal() {
     [ -t 0 ] && [ -t 1 ]
 }
 
+ensure_dotfiles_checkout() {
+    local target="$HOME/.dotfiles"
+
+    if [ "$DOTFILES_ROOT" = "$target" ] || [ -e "$target" ] || [ -L "$target" ]; then
+        return
+    fi
+
+    ln -s "$DOTFILES_ROOT" "$target"
+}
+
 bootstrap_homebrew() {
     if ! is_macos; then
         return 0
@@ -268,6 +278,7 @@ bootstrap_ruby() {
 }
 
 main() {
+    ensure_dotfiles_checkout
     debug "Bootstrapping development environment..."
 
     bootstrap_homebrew

--- a/test/bootstrap_test.rb
+++ b/test/bootstrap_test.rb
@@ -8,6 +8,28 @@ class BootstrapTest < Minitest::Test
 
   MISE_RUBY_COMPILE_WORKAROUND_REMOVE_BY = Date.new(2026, 8, 1)
 
+  def test_ensure_dotfiles_checkout_links_repo_when_target_is_missing
+    with_bootstrap_stub do |env|
+      target = File.join(env.fetch("HOME"), ".dotfiles")
+
+      run_ensure_dotfiles_checkout(env)
+
+      assert File.symlink?(target)
+      assert_equal File.expand_path("..", __dir__), File.readlink(target)
+    end
+  end
+
+  def test_ensure_dotfiles_checkout_preserves_an_existing_entry
+    with_bootstrap_stub do |env|
+      target = File.join(env.fetch("HOME"), ".dotfiles")
+      File.symlink("missing-checkout", target)
+
+      run_ensure_dotfiles_checkout(env)
+
+      assert_equal "missing-checkout", File.readlink(target)
+    end
+  end
+
   def test_homebrew_installer_mode
     homebrew_installer_scenarios.each do |scenario|
       with_bootstrap_stub do |env|

--- a/test/support/bootstrap_script_helper.rb
+++ b/test/support/bootstrap_script_helper.rb
@@ -56,6 +56,10 @@ module BootstrapScriptHelper
     FileUtils.chmod("+x", File.join(bin_dir, "mise"))
   end
 
+  def run_ensure_dotfiles_checkout(env)
+    run_bootstrap_commands(env, nil, "ensure_dotfiles_checkout")
+  end
+
   def run_install_homebrew(env, terminal:)
     run_bootstrap_commands(env, terminal, "install_homebrew")
   end


### PR DESCRIPTION
## What

Ensures a bootstrap checkout living outside `~/.dotfiles` is linked there before bootstrap phases run. The merged mise dotfile declarations use this stable source path.

An existing file, directory, valid symlink, or broken symlink is preserved rather than replaced.

## Testing

- `bundle exec ruby -Itest test/bootstrap_test.rb` — 10 runs, 38 assertions
- Missing-target and existing-entry scenarios
- `bash -n bin/bootstrap`
- ShellCheck
- `mise run lint`

## Review size

37 text lines changed.

Refs #462
Umbrella: #463
