### PR TITLE
Rename Homebrew step around casks

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -73,7 +73,7 @@ debian_non_apt_packages:
 debian_snap_packages: []
 brew:
   taps: []
-  casks:
+brew_casks:
   - nikitabobko/tap/aerospace
   - cursor
   - discord

--- a/lib/dotfiles/config.rb
+++ b/lib/dotfiles/config.rb
@@ -92,7 +92,7 @@ class Dotfiles
     end
 
     def brew_casks
-      env_csv("BREW_CI_CASKS") || config.fetch("brew", {}).fetch("casks", [])
+      env_csv("BREW_CI_CASKS") || config.fetch("brew_casks") { config.fetch("brew", {}).fetch("casks", []) }
     end
 
     def brew_taps

--- a/lib/dotfiles/steps/mac/configure_dropbox_step.rb
+++ b/lib/dotfiles/steps/mac/configure_dropbox_step.rb
@@ -6,7 +6,7 @@ class Dotfiles::Step::ConfigureDropboxStep < Dotfiles::Step
   macos_only
 
   def self.depends_on
-    [Dotfiles::Step::InstallBrewPackagesStep]
+    [Dotfiles::Step::InstallBrewCasksStep]
   end
 
   def should_run?

--- a/lib/dotfiles/steps/mac/configure_login_items_step.rb
+++ b/lib/dotfiles/steps/mac/configure_login_items_step.rb
@@ -6,7 +6,7 @@ class Dotfiles::Step::ConfigureLoginItemsStep < Dotfiles::Step
   macos_only
 
   def self.depends_on
-    [Dotfiles::Step::InstallBrewPackagesStep]
+    [Dotfiles::Step::InstallBrewCasksStep]
   end
 
   def should_run?

--- a/lib/dotfiles/steps/mac/configure_raycast_hotkey_step.rb
+++ b/lib/dotfiles/steps/mac/configure_raycast_hotkey_step.rb
@@ -4,7 +4,7 @@ class Dotfiles::Step::ConfigureRaycastHotkeyStep < Dotfiles::Step
   macos_only
 
   def self.depends_on
-    [Dotfiles::Step::InstallBrewPackagesStep]
+    [Dotfiles::Step::InstallBrewCasksStep]
   end
 
   def run

--- a/lib/dotfiles/steps/mac/configure_spotlight_exclusions_step.rb
+++ b/lib/dotfiles/steps/mac/configure_spotlight_exclusions_step.rb
@@ -6,7 +6,7 @@ class Dotfiles::Step::ConfigureSpotlightExclusionsStep < Dotfiles::Step
   macos_only
 
   def self.depends_on
-    [Dotfiles::Step::InstallBrewPackagesStep]
+    [Dotfiles::Step::InstallBrewCasksStep]
   end
 
   def should_run?

--- a/lib/dotfiles/steps/mac/install_brew_casks_step.rb
+++ b/lib/dotfiles/steps/mac/install_brew_casks_step.rb
@@ -1,5 +1,5 @@
-class Dotfiles::Step::InstallBrewPackagesStep < Dotfiles::Step
-  DESCRIPTION = "Installs Homebrew-managed apps and non-admin formulae.".freeze
+class Dotfiles::Step::InstallBrewCasksStep < Dotfiles::Step
+  DESCRIPTION = "Installs Homebrew casks.".freeze
 
   macos_only
 
@@ -21,7 +21,7 @@ class Dotfiles::Step::InstallBrewPackagesStep < Dotfiles::Step
   end
 
   def run
-    debug "Installing Homebrew-managed apps..."
+    debug "Installing Homebrew casks..."
     install_and_reset
     install_and_reset unless packages_already_installed?
   end
@@ -48,7 +48,7 @@ class Dotfiles::Step::InstallBrewPackagesStep < Dotfiles::Step
     output, status = brew_quiet("bundle", "check", "--file=#{@brewfile_path}", "--no-upgrade")
     @packages_installed_status = status == 0
     @packages_installed_error = output unless @packages_installed_status
-    debug "All Homebrew-managed apps are installed" if @packages_installed_status
+    debug "All Homebrew casks are installed" if @packages_installed_status
     @packages_installed_status
   end
 
@@ -58,7 +58,7 @@ class Dotfiles::Step::InstallBrewPackagesStep < Dotfiles::Step
   end
 
   def add_missing_packages_error
-    message = "Some Homebrew-managed apps are not installed"
+    message = "Some Homebrew casks are not installed"
     details = @packages_installed_error.to_s.strip
     message = "#{message}: #{details}" unless details.empty?
     add_error(message)

--- a/lib/dotfiles/steps/mac/upgrade_brew_packages_step.rb
+++ b/lib/dotfiles/steps/mac/upgrade_brew_packages_step.rb
@@ -4,7 +4,7 @@ class Dotfiles::Step::UpgradeBrewPackagesStep < Dotfiles::Step
   macos_only
 
   def self.depends_on
-    [Dotfiles::Step::InstallBrewPackagesStep]
+    [Dotfiles::Step::InstallBrewCasksStep]
   end
 
   def should_run?

--- a/test/dotfiles/config_test.rb
+++ b/test/dotfiles/config_test.rb
@@ -75,6 +75,13 @@ class ConfigTest < Minitest::Test
     assert_equal "https://github.com/test/dotfiles.git", config["dotfiles_repo"]
   end
 
+  def test_brew_casks_prefers_top_level_config_over_legacy_config
+    config = Dotfiles::Config.new(@fixtures_dir)
+    config.config = {"brew_casks" => ["ghostty"], "brew" => {"casks" => ["firefox"]}}
+
+    assert_equal ["ghostty"], config.brew_casks
+  end
+
   def test_brew_ci_casks_overrides_config
     with_env("BREW_CI_CASKS" => "ghostty, cursor") do
       config = Dotfiles::Config.new(@fixtures_dir)

--- a/test/dotfiles/steps/configure_raycast_hotkey_step_test.rb
+++ b/test/dotfiles/steps/configure_raycast_hotkey_step_test.rb
@@ -7,9 +7,9 @@ class ConfigureRaycastHotkeyStepTest < StepTestCase
     assert_incomplete
   end
 
-  def test_depends_on_homebrew_package_install
+  def test_depends_on_homebrew_cask_install
     assert_includes Dotfiles::Step::ConfigureRaycastHotkeyStep.depends_on,
-      Dotfiles::Step::InstallBrewPackagesStep
+      Dotfiles::Step::InstallBrewCasksStep
   end
 
   def test_run_writes_raycast_defaults

--- a/test/dotfiles/steps/install_brew_casks_step_test.rb
+++ b/test/dotfiles/steps/install_brew_casks_step_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
-class InstallBrewPackagesStepTest < StepTestCase
-  step_class Dotfiles::Step::InstallBrewPackagesStep
+class InstallBrewCasksStepTest < StepTestCase
+  step_class Dotfiles::Step::InstallBrewCasksStep
 
   def test_depends_on_homebrew_update
     assert_equal [Dotfiles::Step::UpdateHomebrewStep], self.class.step_class.depends_on


### PR DESCRIPTION
## What

Renames `InstallBrewPackagesStep` to `InstallBrewCasksStep` around its remaining cask role and updates its dependency graph and tests.

Moves the cask list to the top-level `brew_casks` key while retaining a Config fallback for the old nested key. Installation behavior is unchanged; non-admin mise formula handling remains for a later PR.

## Testing

- Renamed focused step test
- Config tests
- Loader and step graph checks
- Full Ruby suite
- `mise run lint`

## Review size

39 rename-aware text lines.

Refs #462
Umbrella: #463
