### PR TITLE
Add Debian desktop source installer

### DIFF
--- a/lib/dotfiles/debian_desktop_source_installer.rb
+++ b/lib/dotfiles/debian_desktop_source_installer.rb
@@ -1,0 +1,54 @@
+require "securerandom"
+
+class Dotfiles
+  class DebianDesktopSourceInstaller
+    def initialize(system: Dotfiles::SystemAdapter.new)
+      @system = system
+    end
+
+    def install(source = {})
+      return false unless complete?(source)
+      keyring = "/usr/share/keyrings/#{source["name"]}-archive-keyring.gpg"
+      list = "/etc/apt/sources.list.d/#{source["name"]}.list"
+      keyring_exists = @system.file_exist?(keyring)
+      list_current = current_list?(list, source["line"])
+      return true if keyring_exists && list_current
+      temporary = temporary_paths
+      return false unless keyring_exists || install_key(source["key_url"], keyring, temporary)
+      return false unless list_current || install_list(source["line"], list, temporary.last)
+      true
+    ensure
+      @system.rm_rf(temporary) if temporary
+    end
+
+    private
+
+    def complete?(source)
+      source.values_at("name", "key_url", "line").all? { |value| !value.to_s.empty? }
+    end
+
+    def current_list?(path, line)
+      @system.file_exist?(path) && @system.read_file(path).strip == line
+    end
+
+    def install_key(url, destination, temporary)
+      return false unless succeeds?(["curl", "-fsSL", url, "-o", temporary[0]])
+      return false unless succeeds?(["gpg", "--dearmor", "--output", temporary[1], temporary[0]])
+      succeeds?(["sudo", "install", "-m", "644", temporary[1], destination])
+    end
+
+    def install_list(line, destination, temporary)
+      @system.write_file(temporary, "#{line}\n")
+      succeeds?(["sudo", "install", "-m", "644", temporary, destination])
+    end
+
+    def succeeds?(command)
+      @system.execute(command).last == 0
+    end
+
+    def temporary_paths
+      base = "/tmp/dotfiles-debian-source-#{SecureRandom.hex(6)}"
+      ["#{base}.key", "#{base}.gpg", "#{base}.list"]
+    end
+  end
+end

--- a/lib/dotfiles/loader.rb
+++ b/lib/dotfiles/loader.rb
@@ -18,6 +18,7 @@ class Dotfiles
       require "command_helpers"
       require "platform_restrictable"
       require "system_adapter"
+      require "debian_desktop_source_installer"
       require "home_file_set"
       require "step"
       require "step/defaultable"

--- a/test/dotfiles/debian_desktop_source_installer_test.rb
+++ b/test/dotfiles/debian_desktop_source_installer_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+class DebianDesktopSourceInstallerTest < Minitest::Test
+  class FailingSystem < FakeSystemAdapter
+    def initialize(fail_at)
+      super()
+      @fail_at = fail_at
+      @calls = 0
+    end
+
+    def execute(command, quiet: true)
+      result = super
+      @calls += 1
+      (@calls == @fail_at) ? ["failed", 1] : result
+    end
+  end
+
+  def test_install_does_nothing_by_default
+    refute Dotfiles::DebianDesktopSourceInstaller.new(system: @fake_system).install
+  end
+
+  def test_install_adds_missing_keyring_and_source_list
+    assert Dotfiles::DebianDesktopSourceInstaller.new(system: @fake_system).install(source)
+    assert_equal "deb https://example.invalid stable main\n", @fake_system.operations.find { |operation| operation.first == :write_file }.last
+  end
+
+  def test_install_is_idempotent
+    @fake_system.stub_file_content("/usr/share/keyrings/example-archive-keyring.gpg", "key")
+    @fake_system.stub_file_content("/etc/apt/sources.list.d/example.list", source["line"])
+    assert Dotfiles::DebianDesktopSourceInstaller.new(system: @fake_system).install(source)
+    assert_equal [0, 0], [:execute, :write_file].map { |operation| @fake_system.operation_count(operation) }
+  end
+
+  def test_install_stops_and_cleans_up_after_each_command_failure
+    (1..4).each do |fail_at|
+      system = FailingSystem.new(fail_at)
+      refute Dotfiles::DebianDesktopSourceInstaller.new(system: system).install(source)
+      assert_equal [fail_at, 3], [:execute, :rm_rf].map { |operation| system.operation_count(operation) }
+    end
+  end
+
+  def source
+    {"name" => "example", "key_url" => "https://example.invalid/key", "line" => "deb https://example.invalid stable main"}
+  end
+end


### PR DESCRIPTION
## What

Adds a small SystemAdapter-backed collaborator for installing Debian desktop application APT sources.

It validates declarations, preserves current keyrings/source lists, replaces stale source-list content, stops after command failures, and always cleans temporary files. It is not wired into a Step yet.

## Testing

- `bundle exec ruby -Itest test/dotfiles/debian_desktop_source_installer_test.rb` — 4 runs, 12 assertions
- StandardRB
- Perceived-complexity lint
- flog/flay/dead-code checks

## Review size

99 text lines.

Refs #462
Umbrella: #463
