### PR TITLE
Install mise formulae through private Homebrew

### DIFF
--- a/lib/dotfiles/steps/mac/install_brew_casks_step.rb
+++ b/lib/dotfiles/steps/mac/install_brew_casks_step.rb
@@ -1,3 +1,5 @@
+require "json"
+
 class Dotfiles::Step::InstallBrewCasksStep < Dotfiles::Step
   DESCRIPTION = "Installs Homebrew casks.".freeze
 
@@ -91,8 +93,15 @@ class Dotfiles::Step::InstallBrewCasksStep < Dotfiles::Step
     (brew_config["taps"] || []).any? || (brew_config["casks"] || []).any? || formulae_for_brewfile(brew_config).any?
   end
 
-  def formulae_for_brewfile(config)
-    user_has_admin_rights? ? [] : (config["packages"] || [])
+  def formulae_for_brewfile(_config)
+    return [] if user_has_admin_rights?
+
+    output, status = execute(command("mise", "-C", @home, "bootstrap", "packages", "status", "--json"))
+    return [] unless status == 0
+
+    JSON.parse(output).fetch("brew", {}).fetch("packages", []).map { |package| package["package"] }
+  rescue JSON::ParserError
+    []
   end
 
   def brew_config

--- a/test/dotfiles/steps/install_brew_casks_step_test.rb
+++ b/test/dotfiles/steps/install_brew_casks_step_test.rb
@@ -22,6 +22,7 @@ class InstallBrewCasksStepTest < StepTestCase
   def test_run_installs_formulae_for_non_admin_user
     @fake_system.stub_macos
     @fake_system.stub_command("groups", "staff")
+    @fake_system.stub_command(mise_status_command, mise_status_json)
     @fake_system.stub_command(bundle_install_command, "", exit_status: 0)
 
     write_config(:brew, {"brew" => {"packages" => ["duti"], "casks" => ["ghostty"]}})
@@ -41,9 +42,18 @@ class InstallBrewCasksStepTest < StepTestCase
 
   def test_build_brewfile_content_includes_formulae_for_non_admin_user
     @fake_system.stub_command("groups", "staff")
-    content = step.send(:build_brewfile_content, {"packages" => ["duti"], "casks" => []})
+    @fake_system.stub_command(mise_status_command, mise_status_json)
+    content = step.send(:build_brewfile_content, {"casks" => []})
 
     assert_equal %(brew "duti"\n), content
+  end
+
+  def test_build_brewfile_content_omits_formulae_when_mise_status_is_unusable
+    @fake_system.stub_command("groups", "staff")
+    [["bad", 0], ["{}", 1]].each do |output, status|
+      @fake_system.stub_command(mise_status_command, output, exit_status: status)
+      assert_equal "\n", step.send(:build_brewfile_content, {})
+    end
   end
 
   def test_build_brewfile_content_includes_taps_before_casks
@@ -91,6 +101,14 @@ class InstallBrewCasksStepTest < StepTestCase
 
   def brewfile_path
     File.join(@dotfiles_dir, "Brewfile")
+  end
+
+  def mise_status_command
+    "mise -C #{@home} bootstrap packages status --json 2>&1"
+  end
+
+  def mise_status_json
+    '{"brew":{"packages":[{"package":"duti"}]}}'
   end
 
   def bundle_check_command


### PR DESCRIPTION
## What

Preserves non-admin macOS formula installation when mise's package phase is skipped. `InstallBrewCasksStep` reads mise's package-status JSON and includes declared brew formulae in the private-Homebrew Brewfile.

Admin macOS remains casks-only. Failed or invalid mise status output safely yields no formulae.

## Testing

- `bundle exec ruby -Itest test/dotfiles/steps/install_brew_casks_step_test.rb` — 10 runs, 19 assertions
- Admin, non-admin, command-failure, and invalid-JSON cases
- `mise run lint`

## Review size

33 text lines.

Refs #462
Umbrella: #463
