### PR TITLE
Install Debian desktop applications

### DIFF
--- a/.debride-whitelist
+++ b/.debride-whitelist
@@ -3,7 +3,6 @@
 applications=
 config=
 copy_if_exists
-debian_desktop_apps
 down
 install_direct_download
 log_file

--- a/lib/dotfiles/steps/debian/install_debian_desktop_apps_step.rb
+++ b/lib/dotfiles/steps/debian/install_debian_desktop_apps_step.rb
@@ -1,0 +1,46 @@
+class Dotfiles::Step::InstallDebianDesktopAppsStep < Dotfiles::Step
+  DESCRIPTION = "Installs configured Debian desktop applications.".freeze
+  debian_only
+  def self.depends_on
+    [Dotfiles::Step::InstallSystemPackagesStep]
+  end
+
+  def initialize(source_installer: nil, **kwargs)
+    super(**kwargs)
+    @source_installer = source_installer || Dotfiles::DebianDesktopSourceInstaller.new(system: @system)
+  end
+
+  def should_run?
+    allowed_on_platform? && !skip? && missing_packages.any?
+  end
+
+  def run
+    return if skip?
+    @install_error = nil
+    sources_installed = @config.debian_desktop_apps.all? { |app| @source_installer.install(app) }
+    return @install_error = "Failed to install a Debian desktop application source" unless sources_installed
+    packages = missing_packages
+    return if packages.empty?
+    install_command = sudo_command("env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "install", "-y", *packages)
+    output, status = execute(install_command)
+    @install_error = format_command_error(install_command, status, output) unless status == 0
+  end
+
+  def complete?
+    super
+    return true if skip?
+    add_error(@install_error) if @install_error
+    missing_packages.each { |package| add_error("Debian desktop application not installed: #{package}") }
+    errors.empty?
+  end
+
+  private
+
+  def missing_packages
+    @config.debian_desktop_apps.map { |app| app["package"] }.reject { |package| command_succeeds?(command("dpkg", "-s", package)) }
+  end
+
+  def skip?
+    ENV["CI"] || (@system.respond_to?(:running_container?) && @system.running_container?)
+  end
+end

--- a/test/dotfiles/steps/debian/install_debian_desktop_apps_step_test.rb
+++ b/test/dotfiles/steps/debian/install_debian_desktop_apps_step_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+class InstallDebianDesktopAppsStepTest < StepTestCase
+  step_class Dotfiles::Step::InstallDebianDesktopAppsStep
+  SourceInstaller = Struct.new(:result, :installed) { define_method(:install) { |source| (installed << source) && result } }
+  def test_public_methods_do_nothing_by_default
+    refute_should_run
+    assert_complete
+    assert_nil step.run
+  end
+
+  def test_installs_configured_missing_package_after_ensuring_source
+    configure_app
+    installer = SourceInstaller.new(true, [])
+    step(source_installer: installer).run
+    assert_equal ["example"], installer.installed.map { |app| app["name"] }
+    assert_executed "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y example-app"
+  end
+
+  def test_source_failure_stops_package_installation
+    configure_app
+    installer = SourceInstaller.new(false, [])
+    current_step = step(source_installer: installer)
+    current_step.run
+    assert_equal ["example"], installer.installed.map { |app| app["name"] }
+    assert_includes current_step.errors.tap { current_step.complete? }, "Failed to install a Debian desktop application source"
+    refute_executed "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y example-app"
+  end
+
+  def test_skips_in_ci_and_container
+    configure_app
+    with_ci do
+      refute_should_run
+      assert_complete
+      assert_nil step.run
+    end
+    @fake_system.stub_running_container
+    refute_should_run
+    assert_complete
+    assert_nil step.run
+    refute @fake_system.received_operation?(:execute)
+  end
+
+  private
+
+  def configure_app
+    @fake_system.stub_debian
+    app = {"name" => "example", "package" => "example-app", "key_url" => "https://example.invalid/key", "line" => "deb https://example.invalid stable main"}
+    write_config("config", "debian_desktop_apps" => [app])
+    @fake_system.stub_command("dpkg -s example-app >/dev/null 2>&1", "", exit_status: 1)
+  end
+end


### PR DESCRIPTION
## What

Adds the thin Debian desktop application Step consuming the merged declarations and source installer.

For configured missing packages outside CI/containers, it installs required APT sources and then installs packages noninteractively. Existing package owners remain during the compatibility seam.

## Testing

- `bundle exec ruby -Itest test/dotfiles/steps/debian/install_debian_desktop_apps_step_test.rb` — 4 runs, 16 assertions
- Default no-op, missing package, source failure, CI, and container cases
- Loader/step graph validation
- `mise run lint`

## Review size

98 text lines.

Refs #462
Umbrella: #463
