### PR TITLE
Converge with mise before Ruby steps

### DIFF
--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -104,7 +104,7 @@ jobs:
         CI: true
         NONINTERACTIVE: true
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "gum@0.17.0,fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
+        MISE_CI_TOOLS: "gum@0.17.0,github:jdx/aube@1.32.0,npm:@earendil-works/pi-coding-agent@0.82.1,fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_TAPS: ""
         BREW_CI_CASKS: ""
@@ -205,7 +205,7 @@ jobs:
         CI: true
         NONINTERACTIVE: true
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "gum@0.17.0,fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
+        MISE_CI_TOOLS: "gum@0.17.0,github:jdx/aube@1.32.0,npm:@earendil-works/pi-coding-agent@0.82.1,fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_TAPS: ""
         BREW_CI_CASKS: ""

--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -104,7 +104,7 @@ jobs:
         CI: true
         NONINTERACTIVE: true
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
+        MISE_CI_TOOLS: "gum@0.17.0,fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_TAPS: ""
         BREW_CI_CASKS: ""
@@ -205,7 +205,7 @@ jobs:
         CI: true
         NONINTERACTIVE: true
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
+        MISE_CI_TOOLS: "gum@0.17.0,fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_TAPS: ""
         BREW_CI_CASKS: ""

--- a/bin/dotf
+++ b/bin/dotf
@@ -219,6 +219,8 @@ cmd_run() {
     "$SCRIPT_DIR/bootstrap"
     ensure_homebrew_env
     ensure_mise_env
+    run_mise_bootstrap
+    ensure_mise_env
 
     cd "$DOTFILES_DIR"
     ruby -r ./lib/dotfiles.rb -e "Dotfiles::MigrationRunner.new('$LOG_FILE').run_if_existing_machine"

--- a/files/home/.agents/skills
+++ b/files/home/.agents/skills
@@ -1,1 +1,0 @@
-../.dotfiles/files/home/.claude/skills

--- a/files/home/.codex/AGENTS.md
+++ b/files/home/.codex/AGENTS.md
@@ -1,1 +1,0 @@
-../.claude/CLAUDE.md

--- a/files/home/.codex/skills
+++ b/files/home/.codex/skills
@@ -1,1 +1,0 @@
-../.dotfiles/files/home/.claude/skills

--- a/files/home/.config/fish/completions/docker.fish
+++ b/files/home/.config/fish/completions/docker.fish
@@ -1,1 +1,0 @@
-/Applications/OrbStack.app/Contents/MacOS/../Resources/completions/fish/docker.fish

--- a/files/home/.config/fish/completions/kubectl.fish
+++ b/files/home/.config/fish/completions/kubectl.fish
@@ -1,1 +1,0 @@
-/Applications/OrbStack.app/Contents/MacOS/../Resources/completions/fish/kubectl.fish

--- a/files/home/.config/fish/completions/orbctl.fish
+++ b/files/home/.config/fish/completions/orbctl.fish
@@ -1,1 +1,0 @@
-/Applications/OrbStack.app/Contents/MacOS/../Resources/completions/fish/orbctl.fish

--- a/files/home/.factory/AGENTS.md
+++ b/files/home/.factory/AGENTS.md
@@ -1,1 +1,0 @@
-../.claude/CLAUDE.md

--- a/files/home/.local/bin/dotf
+++ b/files/home/.local/bin/dotf
@@ -1,1 +1,0 @@
-../../.dotfiles/bin/dotf

--- a/files/home/.pi/agent/AGENTS.md
+++ b/files/home/.pi/agent/AGENTS.md
@@ -1,1 +1,0 @@
-../../.claude/CLAUDE.md

--- a/files/home/.pi/agent/skills/claude
+++ b/files/home/.pi/agent/skills/claude
@@ -1,1 +1,0 @@
-../../../.dotfiles/files/home/.claude/skills

--- a/lib/dotfiles/migration_runner.rb
+++ b/lib/dotfiles/migration_runner.rb
@@ -41,8 +41,10 @@ class Dotfiles
 
     private
 
+    # Mise creates ~/.local/bin/dotf before migrations run, so only the
+    # migration-version file distinguishes an existing machine from a fresh one.
     def existing_machine?
-      @system.file_exist?(version_file) || @system.file_exist?(dotf_command_file)
+      @system.file_exist?(version_file)
     end
 
     def latest_migration_version
@@ -79,10 +81,6 @@ class Dotfiles
 
     def version_file
       File.join(@home, ".local", "state", "dotf", "migration_version")
-    end
-
-    def dotf_command_file
-      File.join(@home, ".local", "bin", "dotf")
     end
   end
 end

--- a/test/dotfiles/dotf_cli_test.rb
+++ b/test/dotfiles/dotf_cli_test.rb
@@ -202,9 +202,11 @@ class DotfCliTest < Minitest::Test
     commands = File.readlines(log_path, chomp: true)
     assert_equal "bootstrap", commands[0]
     assert_equal "mise activate bash", commands[1]
-    assert_match(/\Aruby -r \.\/lib\/dotfiles\.rb -e Dotfiles::MigrationRunner\.new\('.+'\)\.run_if_existing_machine\z/, commands[2])
-    assert_match(/\Aruby -r \.\/lib\/dotfiles\.rb -e Dotfiles::Runner\.new\('.+'\)\.run\z/, commands[3])
-    assert_equal 4, commands.size
+    assert_match(/\Amise -C .+ bootstrap --yes --update/, commands[2])
+    assert_equal "mise activate bash", commands[3]
+    assert_match(/\Aruby -r \.\/lib\/dotfiles\.rb -e Dotfiles::MigrationRunner\.new\('.+'\)\.run_if_existing_machine\z/, commands[4])
+    assert_match(/\Aruby -r \.\/lib\/dotfiles\.rb -e Dotfiles::Runner\.new\('.+'\)\.run\z/, commands[5])
+    assert_equal 6, commands.size
   end
 
   def bootstrap_stub(log_path)

--- a/test/dotfiles/migration_runner_test.rb
+++ b/test/dotfiles/migration_runner_test.rb
@@ -21,14 +21,14 @@ class MigrationRunnerTest < Minitest::Test
     refute @fake_system.file_exist?(ran_file)
   end
 
-  def test_run_if_existing_machine_runs_when_dotf_command_exists
+  def test_run_if_existing_machine_skips_when_only_dotf_command_exists
     build_migration_class(900000000001)
     @fake_system.stub_file_content(File.join(@home, ".local", "bin", "dotf"), "dotf")
     runner = build_runner
 
     capture_io { runner.run_if_existing_machine }
 
-    assert_equal "yes", @fake_system.read_file(ran_file)
+    refute @fake_system.file_exist?(ran_file)
     assert_equal "900000000001\n", @fake_system.read_file(version_file)
   end
 

--- a/test/trim_mise_config_test.rb
+++ b/test/trim_mise_config_test.rb
@@ -22,7 +22,7 @@ class TrimMiseConfigTest < Minitest::Test
         experimental = true
       TOML
       env = {
-        "MISE_CI_TOOLS" => "ruby@4.0.6, gh",
+        "MISE_CI_TOOLS" => "ruby@4.0.6, gh, npm:@earendil-works/pi-coding-agent@0.82.1",
         "BREW_CI_PACKAGES" => "ba\"sh",
         "DEBIAN_CI_PACKAGES" => "curl"
       }
@@ -32,6 +32,7 @@ class TrimMiseConfigTest < Minitest::Test
       TomlRB.parse(rendered)
       assert_includes rendered, "\"ruby\" = \"4.0.6\""
       assert_includes rendered, "\"gh\" = \"latest\""
+      assert_includes rendered, "--deny-build=@google/genai --deny-build=protobufjs"
       assert_includes rendered, "\"brew:ba\\\"sh\" = \"latest\""
       assert_includes rendered, "\"apt:curl\" = \"latest\""
       assert_includes rendered, "experimental = true"

--- a/tools/ci/trim_mise_config.rb
+++ b/tools/ci/trim_mise_config.rb
@@ -31,7 +31,11 @@ def tool_entries
   csv("MISE_CI_TOOLS").map do |spec|
     name, separator, version = spec.rpartition("@")
     name, version = spec, "latest" if separator.empty?
-    %(#{toml_string(name)} = #{toml_string(version)})
+    if name == "npm:@earendil-works/pi-coding-agent"
+      %(#{toml_string(name)} = { version = #{toml_string(version)}, depends = ["github:jdx/aube"], aube_args = "--deny-build=@google/genai --deny-build=protobufjs" })
+    else
+      %(#{toml_string(name)} = #{toml_string(version)})
+    end
   end
 end
 


### PR DESCRIPTION
## What

Activates the dual-run seam: bootstrap, mise convergence, migrations, then remaining imperative Ruby steps. Refreshes mise environment after convergence and uses only the migration version file to identify existing machines.

## Testing

- Dotf CLI ordering tests
- Migration runner fresh/existing tests
- Full lint

## Review size

22 text lines.

Refs #462
Umbrella: #463