### PR TITLE
Uncouple imperative steps from Ruby home sync

### DIFF
--- a/lib/dotfiles/steps/clear_mise_cache_step.rb
+++ b/lib/dotfiles/steps/clear_mise_cache_step.rb
@@ -1,10 +1,6 @@
 class Dotfiles::Step::ClearMiseCacheStep < Dotfiles::Step
   DESCRIPTION = "Clears mise metadata cache before installing managed tools.".freeze
 
-  def self.depends_on
-    [Dotfiles::Step::SyncHomeDirectoryStep]
-  end
-
   def should_run?
     mise_available? && !mise_offline? && install_needed?
   end

--- a/lib/dotfiles/steps/install_pi_packages_step.rb
+++ b/lib/dotfiles/steps/install_pi_packages_step.rb
@@ -4,7 +4,7 @@ class Dotfiles::Step::InstallPiPackagesStep < Dotfiles::Step
   DESCRIPTION = "Installs Pi packages pinned in Pi settings.".freeze
 
   def self.depends_on
-    [Dotfiles::Step::InstallMiseToolsStep, Dotfiles::Step::SyncHomeDirectoryStep]
+    [Dotfiles::Step::InstallMiseToolsStep]
   end
 
   def should_run?

--- a/lib/dotfiles/steps/mac/configure_downloads_inbox_folder_action_step.rb
+++ b/lib/dotfiles/steps/mac/configure_downloads_inbox_folder_action_step.rb
@@ -4,7 +4,7 @@ class Dotfiles::Step::ConfigureDownloadsInboxFolderActionStep < Dotfiles::Step
   macos_only
 
   def self.depends_on
-    [Dotfiles::Step::CreateStandardFoldersStep, Dotfiles::Step::SyncHomeDirectoryStep]
+    [Dotfiles::Step::CreateStandardFoldersStep]
   end
 
   def should_run?

--- a/lib/dotfiles/steps/mac/install_fonts_step.rb
+++ b/lib/dotfiles/steps/mac/install_fonts_step.rb
@@ -3,17 +3,13 @@ class Dotfiles::Step::InstallFontsStep < Dotfiles::Step
 
   macos_only
 
-  def self.depends_on
-    [Dotfiles::Step::SyncHomeDirectoryStep]
-  end
-
   def should_run?
-    # Fonts are synced by SyncHomeDirectoryStep, no action needed
+    # Fonts are synced by mise bootstrap, no action needed
     false
   end
 
   def run
-    # No-op: fonts are synced by SyncHomeDirectoryStep
+    # No-op: fonts are synced by mise bootstrap
   end
 
   def complete?

--- a/lib/dotfiles/steps/mac/protect_files_step.rb
+++ b/lib/dotfiles/steps/mac/protect_files_step.rb
@@ -10,10 +10,6 @@ class Dotfiles::Step::ProtectFilesStep < Dotfiles::Step
     "Protect Files"
   end
 
-  def self.depends_on
-    [Dotfiles::Step::SyncHomeDirectoryStep]
-  end
-
   private
 
   def protected_files

--- a/lib/dotfiles/steps/mac/protect_git_hooks_step.rb
+++ b/lib/dotfiles/steps/mac/protect_git_hooks_step.rb
@@ -10,10 +10,6 @@ class Dotfiles::Step::ProtectGitHooksStep < Dotfiles::Step
     "Protect Git Hooks"
   end
 
-  def self.depends_on
-    [Dotfiles::Step::SyncHomeDirectoryStep]
-  end
-
   private
 
   def protected_files

--- a/test/dotfiles/steps/install_pi_packages_step_test.rb
+++ b/test/dotfiles/steps/install_pi_packages_step_test.rb
@@ -4,10 +4,7 @@ class InstallPiPackagesStepTest < StepTestCase
   step_class Dotfiles::Step::InstallPiPackagesStep
 
   def test_depends_on_mise_tools_and_home_directory_sync
-    assert_equal [
-      Dotfiles::Step::InstallMiseToolsStep,
-      Dotfiles::Step::SyncHomeDirectoryStep
-    ], self.class.step_class.depends_on
+    assert_equal [Dotfiles::Step::InstallMiseToolsStep], self.class.step_class.depends_on
   end
 
   def test_should_not_run_by_default


### PR DESCRIPTION
Remove obsolete SyncHomeDirectoryStep dependencies now that mise convergence runs before every Ruby step. 29 text lines. Focused tests and lint green.

Refs #462
Umbrella: #463