### PR TITLE
Fold application casks into brew casks

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -84,6 +84,7 @@ brew:
   taps: []
 brew_casks:
   - nikitabobko/tap/aerospace
+  - 1password
   - cursor
   - discord
   - droid
@@ -97,16 +98,10 @@ brew_casks:
   - steam
   - tailscale-app
   - telegram
+  - thebrowsercompany-dia
   - visual-studio-code
   - whatsapp
   - zoom
-applications:
-- name: 1Password
-  path: "/Applications/1Password.app"
-  brew_cask: 1password
-- name: Dia
-  path: "/Applications/Dia.app"
-  brew_cask: thebrowsercompany-dia
 screenshot_settings:
   com.apple.screencapture:
     location: "~/Documents/Inbox"


### PR DESCRIPTION
Move 1Password and Dia into the active brew cask owner and remove their duplicate applications declarations. 9 text lines. Focused tests and lint green.

Refs #462
Umbrella: #463