### PR TITLE
Stop converging the legacy yknotify agent

### DIFF
--- a/lib/dotfiles/steps/mac/install_yknotify_step.rb
+++ b/lib/dotfiles/steps/mac/install_yknotify_step.rb
@@ -1,8 +1,6 @@
 class Dotfiles::Step::InstallYknotifyStep < Dotfiles::Step
   DESCRIPTION = "Installs yknotify notification integration and its LaunchAgent on macOS.".freeze
 
-  include Dotfiles::Step::LaunchCtl
-
   macos_only
 
   def self.depends_on
@@ -11,13 +9,11 @@ class Dotfiles::Step::InstallYknotifyStep < Dotfiles::Step
 
   def should_run?
     return false if ENV["CI"]
-    !yknotify_installed? || !script_current? || !launchagent_current? || !launchagent_loaded?
+    !yknotify_installed? || !script_current?
   end
 
   def run
     install_yknotify_script unless script_current?
-    install_plist(launchagent_path, plist_content) unless launchagent_current?
-    load_launchagent(launchagent_path)
   end
 
   def complete?
@@ -26,8 +22,6 @@ class Dotfiles::Step::InstallYknotifyStep < Dotfiles::Step
     add_error("yknotify binary not found on PATH") unless yknotify_installed?
     add_error("terminal-notifier not found on PATH") unless terminal_notifier_installed?
     add_error("yknotify script not installed at #{script_path}") unless script_current?
-    add_error("LaunchAgent not installed at #{launchagent_path}") unless launchagent_current?
-    add_error("LaunchAgent not loaded: #{launchagent_label}") unless launchagent_loaded?
     @errors.empty?
   end
 
@@ -63,10 +57,6 @@ class Dotfiles::Step::InstallYknotifyStep < Dotfiles::Step
     File.join(script_dir, "yknotify.sh")
   end
 
-  def launchagent_path
-    File.join(@home, "Library/LaunchAgents/com.user.yknotify.plist")
-  end
-
   def source_script_path
     File.join(@dotfiles_dir, "files/yknotify/yknotify.sh")
   end
@@ -79,29 +69,4 @@ class Dotfiles::Step::InstallYknotifyStep < Dotfiles::Step
     @system.read_file(source_script_path)
   end
 
-  def plist_content
-    <<~PLIST
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-          <key>Label</key>
-          <string>com.user.yknotify</string>
-          <key>ProgramArguments</key>
-          <array>
-              <string>/bin/bash</string>
-              <string>#{script_path}</string>
-          </array>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>KeepAlive</key>
-          <true/>
-          <key>StandardOutPath</key>
-          <string>/tmp/yknotify.out</string>
-          <key>StandardErrorPath</key>
-          <string>/tmp/yknotify.err</string>
-      </dict>
-      </plist>
-    PLIST
-  end
 end

--- a/test/dotfiles/steps/install_yknotify_step_test.rb
+++ b/test/dotfiles/steps/install_yknotify_step_test.rb
@@ -42,22 +42,6 @@ class InstallYknotifyStepTest < StepTestCase
     assert_should_run
   end
 
-  def test_should_run_when_launchagent_is_stale
-    stub_yknotify_on_path
-    install_current_files
-    @fake_system.write_file(launchagent_path, "<plist/>\n")
-
-    assert_should_run
-  end
-
-  def test_should_run_when_launchagent_is_unloaded
-    stub_yknotify_on_path
-    stub_launchagent_unloaded
-    install_current_files
-
-    assert_should_run
-  end
-
   def test_run_installs_script_to_xdg_data_dir
     step.run
 
@@ -66,33 +50,10 @@ class InstallYknotifyStepTest < StepTestCase
     assert @fake_system.file_exist?(script_path)
   end
 
-  def test_run_installs_launchagent
-    step.run
-
-    assert_command_run(:mkdir_p, File.dirname(launchagent_path))
-    assert @fake_system.file_exist?(launchagent_path)
-  end
-
-  def test_run_loads_launchagent
-    step.run
-
-    assert_executed("launchctl bootout gui/#{Process.uid} #{launchagent_path} 2>/dev/null || true")
-    assert_executed("launchctl enable gui/#{Process.uid}/com.user.yknotify")
-    assert_executed("launchctl bootstrap gui/#{Process.uid} #{launchagent_path}")
-    assert_executed("launchctl kickstart -k gui/#{Process.uid}/com.user.yknotify")
-  end
-
   def test_script_resolves_yknotify_at_runtime
     step.run
 
     assert_equal "tracked script", @fake_system.read_file(script_path)
-  end
-
-  def test_plist_references_xdg_script_path
-    step.run
-
-    content = @fake_system.read_file(launchagent_path)
-    assert_includes content, script_path
   end
 
   def test_complete_when_all_installed
@@ -126,25 +87,6 @@ class InstallYknotifyStepTest < StepTestCase
     stub_yknotify_on_path
     stub_terminal_notifier_on_path
     stub_launchagent_loaded
-    @fake_system.write_file(launchagent_path, step.send(:plist_content))
-
-    assert_incomplete
-  end
-
-  def test_incomplete_when_launchagent_missing
-    stub_yknotify_on_path
-    stub_terminal_notifier_on_path
-    @fake_system.write_file(script_path, step.send(:script_content))
-
-    assert_incomplete
-  end
-
-  def test_incomplete_when_launchagent_unloaded
-    stub_yknotify_on_path
-    stub_terminal_notifier_on_path
-    stub_launchagent_unloaded
-    install_current_files
-
     assert_incomplete
   end
 
@@ -176,7 +118,6 @@ class InstallYknotifyStepTest < StepTestCase
 
   def install_current_files
     @fake_system.write_file(script_path, step.send(:script_content))
-    @fake_system.write_file(launchagent_path, step.send(:plist_content))
   end
 
   def script_dir


### PR DESCRIPTION
Part of #462.

Leaves tracked script compatibility in place while stopping Ruby from creating or loading the retired com.user.yknotify LaunchAgent. Mise now owns dev.mise.yknotify.

Validation: focused yknotify tests and StandardRB.