### PR TITLE
Retire home sync overlay behavior

### DIFF
--- a/lib/dotfiles/home_file_set.rb
+++ b/lib/dotfiles/home_file_set.rb
@@ -19,20 +19,7 @@ class Dotfiles::HomeFileSet
   private
 
   def source_dirs
-    [source_dir("home"), platform_source_dir, host_source_dir].compact.select { |dir| @system.dir_exist?(dir) }
-  end
-
-  def platform_source_dir
-    if @system.macos?
-      source_dir("home.macos")
-    elsif @system.linux?
-      source_dir("home.linux")
-    end
-  end
-
-  def host_source_dir
-    hostname = @system.hostname.to_s
-    source_dir(File.join("home.hosts", hostname)) unless hostname.empty?
+    [source_dir("home")].select { |dir| @system.dir_exist?(dir) }
   end
 
   def source_dir(name)

--- a/test/dotfiles/home_file_set_test.rb
+++ b/test/dotfiles/home_file_set_test.rb
@@ -5,16 +5,6 @@ class HomeFileSetTest < Minitest::Test
     assert_empty file_set.entries
   end
 
-  def test_entries_prefer_host_over_platform_and_shared_files
-    @fake_system.stub_macos
-    @fake_system.stub_hostname("workspaces")
-    stub_source_file(".config/app/config", "shared")
-    stub_source_file(".config/app/config", "mac", root: "home.macos")
-    stub_source_file(".config/app/config", "host", root: "home.hosts/workspaces")
-
-    assert_equal [source_path(".config/app/config", root: "home.hosts/workspaces")], entry_sources
-  end
-
   def test_entries_ignore_local_state_files
     stub_source_file(".config/fish/fish_variables", "local")
     stub_source_file(".pi/agent/auth.json", "secret")
@@ -26,10 +16,6 @@ class HomeFileSetTest < Minitest::Test
 
   def file_set
     Dotfiles::HomeFileSet.new(dotfiles_dir: @dotfiles_dir, home: @home, system: @fake_system)
-  end
-
-  def entry_sources
-    file_set.entries.map { |entry| entry[:src] }
   end
 
   def source_path(relative, root: "home")

--- a/test/dotfiles/steps/sync_home_directory_step_test.rb
+++ b/test/dotfiles/steps/sync_home_directory_step_test.rb
@@ -101,56 +101,6 @@ class SyncHomeDirectoryStepTest < StepTestCase
     assert_complete
   end
 
-  def test_run_prefers_platform_specific_file_over_shared_file
-    @fake_system.stub_macos
-    stub_source_file(".config/ghostty/config.platform", "font-size = 18")
-    stub_source_file(".config/ghostty/config.platform", "font-size = 16", root: "home.macos")
-
-    step.run
-
-    assert_command_run(
-      :cp,
-      source_path(".config/ghostty/config.platform", root: "home.macos"),
-      home_path(".config/ghostty/config.platform")
-    )
-    refute_command_run(
-      :cp,
-      source_path(".config/ghostty/config.platform", root: "home"),
-      home_path(".config/ghostty/config.platform")
-    )
-  end
-
-  def test_should_not_run_when_platform_specific_file_is_in_sync
-    @fake_system.stub_macos
-    stub_source_file(".config/ghostty/config.platform", "font-size = 18")
-    stub_source_file(".config/ghostty/config.platform", "font-size = 16", root: "home.macos")
-    @fake_system.stub_file_content(home_path(".config/ghostty/config.platform"), "font-size = 16")
-
-    refute_should_run
-    assert_complete
-  end
-
-  def test_run_prefers_host_specific_file_over_platform_file
-    @fake_system.stub_macos
-    @fake_system.stub_hostname("workspaces")
-    stub_source_file(".config/ghostty/config.platform", "font-size = 18")
-    stub_source_file(".config/ghostty/config.platform", "font-size = 16", root: "home.macos")
-    stub_source_file(".config/ghostty/config.platform", "font-size = 12", root: "home.hosts/workspaces")
-
-    step.run
-
-    assert_command_run(
-      :cp,
-      source_path(".config/ghostty/config.platform", root: "home.hosts/workspaces"),
-      home_path(".config/ghostty/config.platform")
-    )
-    refute_command_run(
-      :cp,
-      source_path(".config/ghostty/config.platform", root: "home.macos"),
-      home_path(".config/ghostty/config.platform")
-    )
-  end
-
   def test_run_removes_user_immutable_flag_before_retrying_copy
     dest = home_path(".gem/credentials")
     stub_source_file(".gem/credentials", "stub")


### PR DESCRIPTION
Part of #462.

Removes legacy host/platform overlay selection now that mise renders the explicit platform templates. Shared-tree compatibility remains for later retirement.

Validation: focused HomeFileSet/home-sync tests and StandardRB.