### PR TITLE
Unblock mise bootstrap convergence

### DIFF
--- a/bin/lib/unprotect-managed-files.sh
+++ b/bin/lib/unprotect-managed-files.sh
@@ -2,9 +2,8 @@
 
 # Pre-dotfiles hook for `mise bootstrap` (see [bootstrap.hooks] in
 # files/home/.config/mise/config.toml). The Protect Files / Protect Git Hooks
-# steps mark some managed files immutable; strip the flags only when the repo
-# copy differs so mise's dotfiles phase can overwrite them. The protect steps
-# re-apply the flags afterwards.
+# steps mark some managed files immutable; strip the flags before mise's
+# dotfiles phase copies them. The protect steps re-apply the flags afterwards.
 
 set -e
 
@@ -24,8 +23,7 @@ for relative in "${managed_protected_files[@]}"; do
     target="$HOME/$relative"
     source="$DOTFILES_HOME/$relative"
     [ -f "$target" ] && [ -f "$source" ] || continue
-    cmp -s "$target" "$source" && continue
 
-    chflags nouchg "$target" 2>/dev/null ||
+    chflags noschg,nouchg "$target" 2>/dev/null ||
         sudo chflags noschg,nouchg "$target"
 done

--- a/files/home/.config/mise/config.toml
+++ b/files/home/.config/mise/config.toml
@@ -15,7 +15,7 @@ hk = "1.53.0"
 "npm:@earendil-works/pi-coding-agent" = { version = "0.82.1", depends = ["github:jdx/aube"], minimum_release_age = "0d", aube_args = "--deny-build=@google/genai --deny-build=protobufjs" }
 "go:github.com/mikefarah/yq/v4" = "4.53.3"
 "go:github.com/noperator/yknotify" = "0.0.0-20260324103239-0c773bdadedb"
-"github:aldanial/cloc" = "2.10"
+"github:aldanial/cloc" = { version = "2.10", asset_pattern = "cloc-2.10.pl", bin = "cloc" }
 "github:pkgforge-dev/ghostty-appimage[bin=ghostty]" = { version = "1.3.1", os = ["linux"] }
 "github:nateberkopec/print-label" = "0.1.2"
 watchexec = "2.5.1"

--- a/test/config_syntax_test.rb
+++ b/test/config_syntax_test.rb
@@ -21,6 +21,14 @@ class ConfigSyntaxTest < Minitest::Test
     validate_toml(File.join(ROOT_DIR, ".mise.toml"))
   end
 
+  def test_cloc_uses_its_portable_release_asset
+    config = TomlRB.load_file(File.join(FILES_DIR, "home/.config/mise/config.toml"))
+    cloc = config.fetch("tools").fetch("github:aldanial/cloc")
+
+    assert_equal "cloc-2.10.pl", cloc.fetch("asset_pattern")
+    assert_equal "cloc", cloc.fetch("bin")
+  end
+
   private
 
   def validate_toml(path)

--- a/test/unprotect_managed_files_test.rb
+++ b/test/unprotect_managed_files_test.rb
@@ -1,0 +1,46 @@
+# standard:disable Dotfiles/BanFileSystemClasses -- black-box script test requires real temporary files
+require "test_helper"
+require "fileutils"
+require "open3"
+require "tmpdir"
+
+class UnprotectManagedFilesTest < Minitest::Test
+  SCRIPT = File.expand_path("../bin/lib/unprotect-managed-files.sh", __dir__)
+
+  def test_unprotects_identical_files_before_mise_copies_them
+    Dir.mktmpdir do |dir|
+      home = File.join(dir, "home")
+      source = File.join(home, ".dotfiles/files/home/.aws/credentials")
+      target = File.join(home, ".aws/credentials")
+      trace = File.join(dir, "chflags.log")
+      bin = File.join(dir, "bin")
+
+      FileUtils.mkdir_p([File.dirname(source), File.dirname(target), bin])
+      File.write(source, "same")
+      File.write(target, "same")
+      write_command(bin, "uname", "echo Darwin")
+      write_command(bin, "chflags", 'echo "direct:$*" >> "$TRACE"; exit 1')
+      write_command(bin, "sudo", 'echo "sudo:$*" >> "$TRACE"')
+
+      _stdout, stderr, status = Open3.capture3(
+        {"HOME" => home, "PATH" => "#{bin}:#{ENV.fetch("PATH")}", "TRACE" => trace},
+        "bash", SCRIPT
+      )
+
+      assert status.success?, stderr
+      assert_equal <<~TRACE, File.read(trace)
+        direct:noschg,nouchg #{target}
+        sudo:chflags noschg,nouchg #{target}
+      TRACE
+    end
+  end
+
+  private
+
+  def write_command(bin, name, body)
+    path = File.join(bin, name)
+    File.write(path, "#!/bin/sh\n#{body}\n")
+    FileUtils.chmod(0o755, path)
+  end
+end
+# standard:enable Dotfiles/BanFileSystemClasses


### PR DESCRIPTION
## What

- always clear both user- and system-immutable flags before mise copies protected managed files
- fall back to sudo when system flags require it
- select cloc 2.10's portable Perl release asset and expose it as `cloc`
- add regression coverage for identical protected files and the cloc tool options

## Why

`mise bootstrap` copies managed files even when their contents are unchanged. The hook skipped those files, causing `Operation not permitted`. It also tried only `nouchg` first, which returned successfully without removing `schg`, so the sudo fallback never ran. Fresh cloc 2.10 installs also failed because its release has no platform-specific macOS ARM asset.

## Testing

- `mise run test` (490 runs, 988 assertions)
- pre-commit hooks: StandardRB, complexity, flog, flay, dead code, skills, secrets, large files, human-only, and tests
- successful interactive `dotf run` on macOS

## Review size

64 text lines changed.

Refs #462