### PR TITLE
Remove unused LaunchCtl generality

### DIFF
--- a/lib/dotfiles/step/launchctl.rb
+++ b/lib/dotfiles/step/launchctl.rb
@@ -1,29 +1,19 @@
-require "securerandom"
-require "shellwords"
-
 class Dotfiles
   class Step
     module LaunchCtl
       private
 
-      def install_script(script_path, script_content, mode: 0o755)
+      def install_script(script_path, script_content)
         debug "Installing script to #{script_path}..."
         @system.mkdir_p(File.dirname(script_path))
         @system.write_file(script_path, script_content)
-        @system.chmod(mode, script_path)
+        @system.chmod(0o755, script_path)
       end
 
-      def install_plist(plist_path, plist_content, sudo: false)
+      def install_plist(plist_path, plist_content)
         debug "Installing plist to #{plist_path}..."
         @system.mkdir_p(File.dirname(plist_path))
-        if sudo
-          temp_path = File.join("/tmp", "dotfiles-plist-#{SecureRandom.hex(6)}.plist")
-          @system.write_file(temp_path, plist_content)
-          execute(command("install", "-m", "644", temp_path, plist_path), sudo: true)
-          @system.rm_rf(temp_path)
-        else
-          @system.write_file(plist_path, plist_content)
-        end
+        @system.write_file(plist_path, plist_content)
       end
 
       def load_launchagent(plist_path)
@@ -61,14 +51,6 @@ class Dotfiles
 
       def file_installed_with_content?(path, content)
         @system.file_exist?(path) && @system.read_file(path) == content
-      end
-
-      def script_installed?(script_path)
-        @system.file_exist?(script_path)
-      end
-
-      def plist_installed?(plist_path)
-        @system.file_exist?(plist_path)
       end
     end
   end

--- a/lib/dotfiles/steps/mac/configure_spotlight_battery_step.rb
+++ b/lib/dotfiles/steps/mac/configure_spotlight_battery_step.rb
@@ -12,8 +12,8 @@ class Dotfiles::Step::ConfigureSpotlightBatteryStep < Dotfiles::Step
 
   def run
     return unless fish_path
-    install_script(script_path, script_content) unless script_installed?(script_path)
-    install_spotlight_launchdaemon unless plist_installed?(launchdaemon_path)
+    install_script(script_path, script_content) unless @system.file_exist?(script_path)
+    install_spotlight_launchdaemon unless @system.file_exist?(launchdaemon_path)
     load_launchdaemon(launchdaemon_path)
   end
 
@@ -22,15 +22,15 @@ class Dotfiles::Step::ConfigureSpotlightBatteryStep < Dotfiles::Step
     return true unless battery_mode_enabled?
 
     add_error("Fish not found for Spotlight battery toggle") unless fish_path
-    add_error("Spotlight battery script not installed at #{script_path}") unless script_installed?(script_path)
-    add_error("LaunchDaemon not installed at #{launchdaemon_path}") unless plist_installed?(launchdaemon_path)
+    add_error("Spotlight battery script not installed at #{script_path}") unless @system.file_exist?(script_path)
+    add_error("LaunchDaemon not installed at #{launchdaemon_path}") unless @system.file_exist?(launchdaemon_path)
     @errors.empty?
   end
 
   private
 
   def battery_toggle_installed?
-    script_installed?(script_path) && plist_installed?(launchdaemon_path)
+    @system.file_exist?(script_path) && @system.file_exist?(launchdaemon_path)
   end
 
   def script_content


### PR DESCRIPTION
LaunchCtl plist installation is only used for a user LaunchAgent, so the never-called sudo/temp-file branch and its dependencies can go. The Spotlight step now uses the system adapter directly for its existence checks instead of one-line wrappers.

Net: 18 lines removed.

Validation:
- Full Ruby test suite
- `mise run lint`
- Focused wallpaper and Spotlight battery tests