### PR TITLE
Remove unused repository injection

### DIFF
--- a/.debride-whitelist
+++ b/.debride-whitelist
@@ -1,6 +1,5 @@
 # Public API and framework hooks that debride cannot see statically.
 /^on_/
-config=
 down
 install_direct_download
 log_file

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,4 @@
 ---
-dotfiles_repo: https://github.com/nateberkopec/dotfiles.git
 standard_folders:
 - Documents/Inbox
 - Documents/Code.nosync

--- a/docs/implementing-steps.md
+++ b/docs/implementing-steps.md
@@ -188,7 +188,6 @@ class SyncConfigDirectoryStepTest < Minitest::Test
     @system = FakeSystemAdapter.new
     @step = Dotfiles::Step::SyncConfigDirectoryStep.new(
       debug: false,
-      dotfiles_repo: "https://github.com/user/dotfiles.git",
       dotfiles_dir: "/tmp/dotfiles",
       home: "/tmp/home",
       system: @system

--- a/lib/dotfiles/config.rb
+++ b/lib/dotfiles/config.rb
@@ -3,7 +3,6 @@ require "yaml"
 class Dotfiles
   class Config
     attr_reader :dotfiles_dir
-    attr_writer :config
 
     def initialize(dotfiles_dir, system: SystemAdapter.new)
       @dotfiles_dir = dotfiles_dir
@@ -13,10 +12,6 @@ class Dotfiles
 
     def config
       @config ||= load_config
-    end
-
-    def dotfiles_repo
-      config["dotfiles_repo"] || "https://github.com/nateberkopec/dotfiles.git"
     end
 
     def home

--- a/lib/dotfiles/migration.rb
+++ b/lib/dotfiles/migration.rb
@@ -23,9 +23,8 @@ class Dotfiles
       name.gsub(/^Dotfiles::Migration::/, "").gsub(/([A-Z]+)([A-Z][a-z])/, '\\1 \\2').gsub(/([a-z\d])([A-Z])/, '\\1 \\2')
     end
 
-    def initialize(debug:, dotfiles_repo:, dotfiles_dir:, home:, system: SystemAdapter.new, config: nil)
-      @debug, @dotfiles_repo, @dotfiles_dir, @home, @system = debug, dotfiles_repo, dotfiles_dir, home, system
-      @config = config || Config.new(dotfiles_dir, system: system)
+    def initialize(dotfiles_dir:, home:, system: SystemAdapter.new)
+      @dotfiles_dir, @home, @system = dotfiles_dir, home, system
     end
 
     def allowed_on_platform?

--- a/lib/dotfiles/migration_runner.rb
+++ b/lib/dotfiles/migration_runner.rb
@@ -2,10 +2,9 @@ class Dotfiles
   class MigrationRunner
     attr_reader :home
 
-    def initialize(log_file = nil, system: SystemAdapter.new, home: nil, dotfiles_dir: nil, debug: nil)
+    def initialize(log_file = nil, system: SystemAdapter.new, home: nil, dotfiles_dir: nil)
       Dotfiles.log_file = log_file if log_file
       @system = system
-      @debug = debug.nil? ? ENV["DEBUG"] == "true" : debug
       @dotfiles_dir = dotfiles_dir || Dotfiles.determine_dotfiles_dir
       @config = Config.new(@dotfiles_dir, system: system)
       @home = home || @config.home
@@ -65,12 +64,9 @@ class Dotfiles
 
     def migration_params
       {
-        debug: @debug,
-        dotfiles_repo: @config.dotfiles_repo,
         dotfiles_dir: @dotfiles_dir,
         home: @home,
-        system: @system,
-        config: @config
+        system: @system
       }
     end
 

--- a/lib/dotfiles/runner.rb
+++ b/lib/dotfiles/runner.rb
@@ -30,7 +30,6 @@ class Dotfiles
     def build_step_params
       {
         debug: @debug,
-        dotfiles_repo: @config.dotfiles_repo,
         dotfiles_dir: @config.dotfiles_dir,
         home: @config.home,
         config: @config

--- a/lib/dotfiles/step.rb
+++ b/lib/dotfiles/step.rb
@@ -76,8 +76,8 @@ class Dotfiles
       context[:result] << step
     end
 
-    def initialize(debug:, dotfiles_repo:, dotfiles_dir:, home:, system: SystemAdapter.new, config: nil)
-      @debug, @dotfiles_repo, @dotfiles_dir, @home, @system = debug, dotfiles_repo, dotfiles_dir, home, system
+    def initialize(debug:, dotfiles_dir:, home:, system: SystemAdapter.new, config: nil)
+      @debug, @dotfiles_dir, @home, @system = debug, dotfiles_dir, home, system
       @config = config || Config.new(dotfiles_dir, system: system)
       reset_state
     end

--- a/test/dotfiles/adopt_mise_bootstrap_migration_test.rb
+++ b/test/dotfiles/adopt_mise_bootstrap_migration_test.rb
@@ -37,8 +37,6 @@ class AdoptMiseBootstrapMigrationTest < Minitest::Test
 
   def migration
     Dotfiles::Migration::AdoptMiseBootstrap.new(
-      debug: false,
-      dotfiles_repo: "https://github.com/test/dotfiles.git",
       dotfiles_dir: @dotfiles_dir,
       home: @home,
       system: @fake_system

--- a/test/dotfiles/config_test.rb
+++ b/test/dotfiles/config_test.rb
@@ -36,22 +36,10 @@ class ConfigTest < Minitest::Test
     assert_empty Dotfiles::Config.new("/nonexistent/dir").brew_casks
   end
 
-  def test_dotfiles_repo_from_config
-    config = Dotfiles::Config.new(@fixtures_dir)
-
-    assert_equal "https://github.com/test/dotfiles.git", config.dotfiles_repo
-  end
-
-  def test_dotfiles_repo_default_fallback
-    config = Dotfiles::Config.new("/nonexistent/dir")
-
-    assert_equal "https://github.com/nateberkopec/dotfiles.git", config.dotfiles_repo
-  end
-
   def test_fetch_returns_config_value
     config = Dotfiles::Config.new(@fixtures_dir)
 
-    assert_equal "https://github.com/test/dotfiles.git", config.fetch("dotfiles_repo")
+    assert_equal ["firefox", "dropbox"], config.fetch("brew_casks")
   end
 
   def test_fetch_returns_default_for_missing_key
@@ -63,7 +51,7 @@ class ConfigTest < Minitest::Test
   def test_bracket_accessor_returns_config_value
     config = Dotfiles::Config.new(@fixtures_dir)
 
-    assert_equal "https://github.com/test/dotfiles.git", config["dotfiles_repo"]
+    assert_equal ["firefox", "dropbox"], config["brew_casks"]
   end
 
   def test_brew_ci_casks_overrides_config

--- a/test/dotfiles/migration_runner_test.rb
+++ b/test/dotfiles/migration_runner_test.rb
@@ -55,7 +55,7 @@ class MigrationRunnerTest < Minitest::Test
   private
 
   def build_runner
-    Dotfiles::MigrationRunner.new(nil, system: @fake_system, home: @home, dotfiles_dir: @dotfiles_dir, debug: false)
+    Dotfiles::MigrationRunner.new(nil, system: @fake_system, home: @home, dotfiles_dir: @dotfiles_dir)
   end
 
   def build_migration_class(version)

--- a/test/dotfiles/migration_test.rb
+++ b/test/dotfiles/migration_test.rb
@@ -128,8 +128,6 @@ class MigrationTest < Minitest::Test
 
   def create_migration(migration_class, **overrides)
     defaults = {
-      debug: false,
-      dotfiles_repo: "https://github.com/test/dotfiles.git",
       dotfiles_dir: @dotfiles_dir,
       home: @home,
       system: @fake_system

--- a/test/fixtures/config/config.yml
+++ b/test/fixtures/config/config.yml
@@ -1,6 +1,4 @@
 ---
-dotfiles_repo: https://github.com/test/dotfiles.git
-
 brew_casks:
   - firefox
   - dropbox

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,7 +39,6 @@ class Minitest::Test
   def create_step(step_class, **overrides)
     defaults = {
       debug: false,
-      dotfiles_repo: "https://github.com/test/dotfiles.git",
       dotfiles_dir: @dotfiles_dir,
       home: @home,
       system: @fake_system


### PR DESCRIPTION
Follow-up cleanup after #511.

The repository URL, migration debug flag, and injected migration config were no longer read by any setup or migration path. This removes those values from config and constructors without changing execution.

Net: 33 lines removed.

Validation:
- Full Ruby test suite
- `mise run lint`
- Focused config and migration tests