### PR TITLE
Remove unused Codespaces probe

### DIFF
--- a/.debride-whitelist
+++ b/.debride-whitelist
@@ -6,4 +6,3 @@ install_direct_download
 log_file
 print_steps
 run_if_existing_machine
-running_codespaces?

--- a/lib/dotfiles/system_adapter.rb
+++ b/lib/dotfiles/system_adapter.rb
@@ -15,10 +15,6 @@ class Dotfiles
       linux? && File.exist?("/etc/debian_version")
     end
 
-    def running_codespaces?
-      ENV["CODESPACES"] == "true"
-    end
-
     def running_container?
       file_exist?("/.dockerenv") ||
         (file_exist?("/proc/1/cgroup") && read_file("/proc/1/cgroup").include?("docker"))

--- a/test/dotfiles/system_adapter_test.rb
+++ b/test/dotfiles/system_adapter_test.rb
@@ -169,18 +169,6 @@ class SystemAdapterTest < Minitest::Test
     assert_includes error.message, "boom"
   end
 
-  def test_running_codespaces_is_true_when_env_is_true
-    with_env("CODESPACES" => "true") do
-      assert Dotfiles::SystemAdapter.new.running_codespaces?
-    end
-  end
-
-  def test_running_codespaces_is_false_by_default
-    with_env("CODESPACES" => nil) do
-      refute Dotfiles::SystemAdapter.new.running_codespaces?
-    end
-  end
-
   def test_running_container_detects_dockerenv
     adapter = Dotfiles::SystemAdapter.new
 


### PR DESCRIPTION
## Summary

- remove the unreferenced `SystemAdapter#running_codespaces?` method
- remove its tests and dead-code exemption

No production code calls this probe, so this is a pure dead-code deletion with no behavior change.

## Size

0 additions, 17 deletions (net -17 lines).

## Validation

- `git diff --check origin/main...HEAD`
- Ruby suite excluding the pre-existing Bundler/PATH-sensitive `FlogFlayTasksTest`: 370 runs, 823 assertions, 0 failures
- StandardRB
- RuboCop perceived-complexity check
- dead-code check
- flog and flay
