### PR TITLE
Flatten runner result aggregation

### DIFF
--- a/lib/dotfiles/runner.rb
+++ b/lib/dotfiles/runner.rb
@@ -187,31 +187,16 @@ class Dotfiles
     end
 
     def merge_step_result(data, results)
-      append_table_row(data, results)
-      append_failed_step(data, results)
-      append_step_messages(data, results)
-    end
-
-    def append_table_row(data, results)
-      results[:table_data] << [data[:index], data[:name], data[:complete] ? "✓" : "✗", table_row_ran(data)]
-    end
-
-    def table_row_ran(data)
-      data[:step].ran? ? "Yes" : "No"
-    end
-
-    def append_failed_step(data, results)
+      step = data[:step]
+      results[:table_data] << [data[:index], data[:name], data[:complete] ? "✓" : "✗", step.ran? ? "Yes" : "No"]
       results[:failed_steps] << data[:name] unless data[:complete]
-    end
-
-    def append_step_messages(data, results)
-      results[:warnings].concat(data[:step].warnings)
-      results[:notices].concat(data[:step].notices)
+      results[:warnings].concat(step.warnings)
+      results[:notices].concat(step.notices)
       append_step_errors(data, results)
     end
 
     def append_step_errors(data, results)
-      results[:errors].concat(data[:errors].map { |err| {step: data[:name], message: err} })
+      results[:errors].concat(data[:errors].map { |error| {step: data[:name], message: error} })
     end
   end
 end


### PR DESCRIPTION
## Summary

- inline four single-use result-aggregation helpers into `merge_step_result`
- keep the same table rows, failed-step names, warnings, notices, and structured errors
- remove indirection without changing runner output

## Size

5 additions, 20 deletions (net -15 lines).

## Validation

- `git diff --check origin/main...HEAD`
- Ruby suite excluding the pre-existing Bundler/PATH-sensitive `FlogFlayTasksTest`: 372 runs, 825 assertions, 0 failures
- StandardRB
- RuboCop perceived-complexity check
- dead-code check
- flog and flay
