### PR TITLE
Update managed package versions

### DIFF
--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -104,7 +104,7 @@ jobs:
         CI: true
         NONINTERACTIVE: true
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "gum@0.17.0,github:jdx/aube@1.32.0,npm:@earendil-works/pi-coding-agent@0.82.1,fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
+        MISE_CI_TOOLS: "gum@0.17.0,github:jdx/aube@1.36.0,npm:@earendil-works/pi-coding-agent@0.83.0,fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_CASKS: ""
         DEBIAN_CI_PACKAGES: "trash-cli"
@@ -202,7 +202,7 @@ jobs:
         CI: true
         NONINTERACTIVE: true
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "gum@0.17.0,github:jdx/aube@1.32.0,npm:@earendil-works/pi-coding-agent@0.82.1,fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
+        MISE_CI_TOOLS: "gum@0.17.0,github:jdx/aube@1.36.0,npm:@earendil-works/pi-coding-agent@0.83.0,fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_CASKS: ""
       run: |

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -210,7 +210,6 @@ bootstrap_mise() {
         fi
     fi
 
-    configure_mise_ruby_precompiled
     eval "$(mise activate bash)"
 }
 
@@ -218,14 +217,6 @@ seed_global_mise_config() {
     debug "Seeding global mise config from the repo..."
     mkdir -p "$HOME/.config/mise"
     cp "$DOTFILES_ROOT/files/home/.config/mise/config.toml" "$HOME/.config/mise/config.toml"
-}
-
-configure_mise_ruby_precompiled() {
-    # TODO: Remove this once mise 2026.8.0 makes precompiled Rubies the default.
-    # test/bootstrap_test.rb intentionally fails after 2026-08-01 if this remains.
-    debug "Configuring mise to use precompiled Rubies..."
-    export MISE_RUBY_COMPILE=false
-    stdout_quiet_unless_debug mise settings set ruby.compile false
 }
 
 main() {

--- a/files/home/.config/mise/config.toml
+++ b/files/home/.config/mise/config.toml
@@ -2,7 +2,7 @@
 [tools]
 ruby = "4.0.6"
 node = "26.5.0"
-"github:jdx/aube" = "1.32.0"
+"github:jdx/aube" = "1.36.0"
 go = "1.26.4"
 rust = "1.96.1"
 hk = "1.53.0"
@@ -10,34 +10,34 @@ hk = "1.53.0"
 "cargo:difftastic" = "0.69.0"
 "cargo:starship" = "1.26.0"
 "gem:try-cli" = "1.9.3"
-"npm:@openai/codex" = { version = "0.145.0", depends = ["github:jdx/aube"] }
+"npm:@openai/codex" = { version = "0.146.0", depends = ["github:jdx/aube"] }
 "npm:sfw" = { version = "2.0.6", depends = ["github:jdx/aube"] }
-"npm:@earendil-works/pi-coding-agent" = { version = "0.82.1", depends = ["github:jdx/aube"], minimum_release_age = "0d", aube_args = "--deny-build=@google/genai --deny-build=protobufjs" }
+"npm:@earendil-works/pi-coding-agent" = { version = "0.83.0", depends = ["github:jdx/aube"], minimum_release_age = "0d", aube_args = "--deny-build=@google/genai --deny-build=protobufjs" }
 "go:github.com/mikefarah/yq/v4" = "4.53.3"
 "go:github.com/noperator/yknotify" = "0.0.0-20260324103239-0c773bdadedb"
 "github:aldanial/cloc" = { version = "2.10", asset_pattern = "cloc-2.10.pl", bin = "cloc" }
 "github:pkgforge-dev/ghostty-appimage[bin=ghostty]" = { version = "1.3.1", os = ["linux"] }
 "github:nateberkopec/print-label" = "0.1.2"
 watchexec = "2.5.1"
-fnox = "1.30.0"
+fnox = "1.31.1"
 bat = "0.26.1"
 cmake = "4.3.3"
 fd = "10.4.2"
-fzf = "0.73.1"
+fzf = "0.74.1"
 "aqua:fish-shell/fish-shell" = "4.8.1"
 gh = "2.96.0"
 git-lfs = "3.7.1"
 gum = "0.17.0"
 jq = "1.8.2"
 lazygit = "0.63.0"
-ripgrep = "15.1.0"
+ripgrep = "15.2.0"
 shellcheck = "0.11.0"
 tmux = "3.7b"
 zoxide = "0.10.0"
-pkl = "0.31.1"
-claude = "2.1.219"
+pkl = "0.32.1"
+claude = "2.1.220"
 gitleaks = "8.30.1"
-"1password-cli" = "2.35.0"
+"1password-cli" = "2.38.1"
 acli = "1.3.22-stable"
 heroku = { version = "11.8.1", depends = ["github:jdx/aube"], aube_args = "--deny-build=cpu-features --deny-build=protobufjs --deny-build=ssh2 --deny-build=yarn" }
 "aqua:planetscale/cli" = "0.307.0"
@@ -51,7 +51,6 @@ legacy_version_file = true
 experimental = true
 npm.package_manager = "aube"
 github.credential_command = "gh auth token"
-ruby.compile = false
 fetch_remote_versions_cache = "7d"
 minimum_release_age = "3d"
 http_timeout = "5s"

--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -5,9 +5,9 @@
   "defaultThinkingLevel": "medium",
   "hideThinkingBlock": false,
   "packages": [
-    "npm:pi-mcp-adapter@2.12.1",
+    "npm:pi-mcp-adapter@2.15.0",
     "npm:pi-ding@0.2.2",
-    "npm:pi-subagents@0.36.0",
+    "npm:pi-subagents@0.37.2",
     "npm:pi-web-providers@3.5.1"
   ],
   "npmCommand": [

--- a/test/bootstrap_test.rb
+++ b/test/bootstrap_test.rb
@@ -1,12 +1,9 @@
 require "test_helper"
-require "date"
 require_relative "support/bootstrap_script_helper"
 
 # standard:disable Dotfiles/BanFileSystemClasses
 class BootstrapTest < Minitest::Test
   include BootstrapScriptHelper
-
-  MISE_RUBY_COMPILE_WORKAROUND_REMOVE_BY = Date.new(2026, 8, 1)
 
   def test_ensure_dotfiles_checkout_links_repo_when_target_is_missing
     with_bootstrap_stub do |env|
@@ -90,16 +87,6 @@ class BootstrapTest < Minitest::Test
     end
   end
 
-  def test_bootstrap_mise_sets_ruby_compile_false
-    with_bootstrap_stub do |env|
-      write_mise_stub(env)
-      run_bootstrap_mise(env)
-
-      assert_includes logged_mise_commands(env), "mise activate bash"
-      assert_includes logged_mise_commands(env), "mise settings set ruby.compile false"
-    end
-  end
-
   def test_bootstrap_mise_seeds_global_config_before_activation
     with_bootstrap_stub do |env|
       global_config = File.join(env.fetch("HOME"), ".config", "mise", "config.toml")
@@ -112,11 +99,6 @@ class BootstrapTest < Minitest::Test
       expected = File.read(File.expand_path("../files/home/.config/mise/config.toml", __dir__))
       assert_equal expected, File.read(env.fetch("MISE_CONFIG_AT_ACTIVATION_LOG"))
     end
-  end
-
-  def test_mise_ruby_compile_workaround_expires
-    assert Date.today < MISE_RUBY_COMPILE_WORKAROUND_REMOVE_BY,
-      "Remove bootstrap's ruby.compile workaround; mise 2026.8.0 should make this default."
   end
 
   private

--- a/test/skills/flog_flay_tasks_test.rb
+++ b/test/skills/flog_flay_tasks_test.rb
@@ -38,10 +38,15 @@ class FlogFlayTasksTest < Minitest::Test
         exit ENV.fetch("TOOL_STATUS").to_i
       RUBY
       File.chmod(0o755, bundle)
-      code = "require 'rake'; load File.join(ENV.fetch('ROOT'), 'Rakefile'); Rake::Task[ENV.fetch('TASK')].invoke"
-      env = {"PATH" => "#{dir}:#{ENV.fetch("PATH")}", "ROOT" => ROOT, "TASK" => task,
+      code = <<~RUBY
+        ENV["PATH"] = ENV.fetch("STUB_BIN") + File::PATH_SEPARATOR + ENV.fetch("PATH")
+        require "rake"
+        load File.join(ENV.fetch("ROOT"), "Rakefile")
+        Rake::Task[ENV.fetch("TASK")].invoke
+      RUBY
+      env = {"ROOT" => ROOT, "STUB_BIN" => dir, "TASK" => task,
              "TOOL_OUTPUT" => tool_output, "TOOL_STATUS" => tool_status.to_s}
-      return Open3.capture2e(env, "ruby", "-e", code, chdir: ROOT)
+      return Open3.capture2e(env, RbConfig.ruby, "-e", code, chdir: ROOT)
     end
   end
 end

--- a/test/trim_mise_config_test.rb
+++ b/test/trim_mise_config_test.rb
@@ -22,7 +22,7 @@ class TrimMiseConfigTest < Minitest::Test
         experimental = true
       TOML
       env = {
-        "MISE_CI_TOOLS" => "ruby@4.0.6, gh, npm:@earendil-works/pi-coding-agent@0.82.1",
+        "MISE_CI_TOOLS" => "ruby@4.0.6, gh, npm:@earendil-works/pi-coding-agent@0.83.0",
         "BREW_CI_PACKAGES" => "ba\"sh",
         "DEBIAN_CI_PACKAGES" => "curl"
       }


### PR DESCRIPTION
## Summary

- update the requested mise and Pi package pins
- update CI's matching aube and Pi tool versions
- remove the expired `ruby.compile = false` workaround now that mise 2026.8.0 defaults to precompiled Rubies
- keep the flog/flay task tests isolated from Bundler's executable-path rewriting on Ruby 4.0.6

Homebrew casks remain declared without version pins, so `1password`, `cursor`, and `whatsapp` will upgrade to their latest cask versions during convergence without repository changes.

## Tests

- `bundle exec rake test`
- pre-commit hooks: StandardRB, complexity, secrets, dead code, flog, flay, skills, and full test suite
- JSON and TOML parse validation
