### PR TITLE
Simplify mise task flag mapping

### DIFF
--- a/files/home/.claude/skills/dev-env-setup/scripts/check-dev-env/mise-tasks.fish
+++ b/files/home/.claude/skills/dev-env-setup/scripts/check-dev-env/mise-tasks.fish
@@ -29,17 +29,6 @@ function mark_mise_task
             set -g has_test 1
         case lint 'lint:*'
             set -g has_lint 1
-            mark_lint_task "$task_name"
-        case large-files
-            set -g has_large_files 1
-        case complexity
-            set -g has_complexity 1
-        case dead-code
-            set -g has_dead_code 1
-        case flog
-            set -g has_flog 1
-        case flay
-            set -g has_flay 1
         case serve dev
             set -g has_serve_or_dev 1
             if test "$task_name" = "serve"
@@ -48,20 +37,11 @@ function mark_mise_task
         case build
             set -g has_build 1
     end
-end
 
-function mark_lint_task
-    switch "$argv[1]"
-        case lint:large-files
-            set -g has_large_files 1
-        case lint:complexity
-            set -g has_complexity 1
-        case lint:dead-code
-            set -g has_dead_code 1
-        case lint:flog
-            set -g has_flog 1
-        case lint:flay
-            set -g has_flay 1
+    set normalized_task_name (string replace -r '^lint:' '' -- "$task_name")
+    if contains -- "$normalized_task_name" large-files complexity dead-code flog flay
+        set flag_name (string replace -- - _ "$normalized_task_name")
+        set -g has_$flag_name 1
     end
 end
 

--- a/test/skills/dev_env_mise_task_flags_test.rb
+++ b/test/skills/dev_env_mise_task_flags_test.rb
@@ -1,0 +1,48 @@
+# standard:disable Dotfiles/BanFileSystemClasses -- black-box checker tests require temporary files
+require_relative "../test_helper"
+require "open3"
+require "tmpdir"
+
+class DevEnvMiseTaskFlagsTest < Minitest::Test
+  CHECK = File.expand_path("../../files/home/.claude/skills/dev-env-setup/scripts/check-dev-env.fish", __dir__)
+
+  def setup
+    skip "fish is required for checker tests" unless system("fish", "--version", out: File::NULL, err: File::NULL)
+  end
+
+  def test_allowlisted_families_pass_in_bare_and_lint_forms
+    families = %w[large-files complexity dead-code flog flay]
+
+    ["", "lint:"].each do |prefix|
+      output = run_checker(families.map { |family| "#{prefix}#{family}" })
+
+      families.each { |family| assert_report output, "PASS", "mise task: lint:#{family}" }
+    end
+  end
+
+  def test_generic_lint_and_unrelated_tasks_do_not_enable_family_checks
+    families = %w[large-files complexity dead-code flog flay]
+
+    %w[lint lint:flog-extra].each do |lint_task|
+      output = run_checker([lint_task, "docs", "large_files"])
+
+      assert_report output, "PASS", "mise task: lint"
+      families.each { |family| assert_report output, "FAIL", "mise task: lint:#{family}" }
+    end
+  end
+
+  private
+
+  def run_checker(tasks)
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "Gemfile"), "source \"https://rubygems.org\"\n")
+      File.write(File.join(dir, "mise.toml"), tasks.map { |task| "[tasks.\"#{task}\"]" }.join("\n"))
+      return Open3.capture2e({"NO_COLOR" => "1"}, "fish", CHECK, dir).first
+    end
+  end
+
+  def assert_report(output, status, label)
+    assert_includes output, "  #{status}  #{label}"
+  end
+end
+# standard:enable Dotfiles/BanFileSystemClasses


### PR DESCRIPTION
## Summary
- replace ten repetitive task-to-flag branches with one normalized allowlist
- remove the now-unused `mark_lint_task` helper
- preserve bare tasks, `lint:` aliases, generic lint, and unrelated-task behavior
- test emitted checker reports through temporary mise configurations

The production Fish code is 20 lines shorter.

## Testing
- `bundle exec rake test`
- `mise run lint`
- independent subagent review and fix pass