### PR TITLE
Prune redundant macOS step helpers

### DIFF
--- a/lib/dotfiles/steps/mac/install_fonts_step.rb
+++ b/lib/dotfiles/steps/mac/install_fonts_step.rb
@@ -19,15 +19,11 @@ class Dotfiles::Step::InstallFontsStep < Dotfiles::Step
       add_error("Failed to check installed fonts (fc-list command failed)")
       return false
     end
-    report_missing_fonts(installed)
+    missing_fonts(installed).each { |font_path| add_error("Font not installed: #{File.basename(font_path)}") }
     @errors.empty?
   end
 
   private
-
-  def report_missing_fonts(installed)
-    missing_fonts(installed).each { |font_path| add_error("Font not installed: #{File.basename(font_path)}") }
-  end
 
   def missing_fonts(installed)
     font_files.reject { |path| installed.include?(File.basename(path, ".ttf")) }

--- a/lib/dotfiles/steps/mac/protect_files_step.rb
+++ b/lib/dotfiles/steps/mac/protect_files_step.rb
@@ -17,9 +17,7 @@ class Dotfiles::Step::ProtectFilesStep < Dotfiles::Step
   end
 
   def immutable_flag(file)
-    return "uchg" if user_credentials_file?(file)
-
-    "schg"
+    user_credentials_file?(file) ? "uchg" : "schg"
   end
 
   def protect_with_sudo?(file)
@@ -27,9 +25,7 @@ class Dotfiles::Step::ProtectFilesStep < Dotfiles::Step
   end
 
   def protected_file_mode(file)
-    return 0o600 if user_credentials_file?(file)
-
-    nil
+    user_credentials_file?(file) ? 0o600 : nil
   end
 
   def pi_extension_files

--- a/test/dotfiles/steps/install_fonts_step_test.rb
+++ b/test/dotfiles/steps/install_fonts_step_test.rb
@@ -49,16 +49,4 @@ class InstallFontsStepTest < StepTestCase
   def stub_font_present(name)
     stub_installed_fonts("#{name}.ttf\n#{name}")
   end
-
-  def with_env(vars)
-    originals = vars.keys.to_h { |k| [k, ENV[k]] }
-    vars.each { |k, v| ENV[k] = v }
-    begin
-      rebuild_step!
-      yield
-    ensure
-      vars.each_key { |k| originals[k].nil? ? ENV.delete(k) : ENV[k] = originals[k] }
-      rebuild_step!
-    end
-  end
 end


### PR DESCRIPTION
## Summary
- replace verbose credential value selectors with direct expressions
- inline a single-use missing-font reporting helper
- remove a duplicate test environment helper in favor of the shared implementation

This removes 20 lines without changing commands, errors, ordering, or state.

## Testing
- focused macOS step tests
- `bundle exec rake test`
- `mise run lint`
- independent subagent review