### PR TITLE
Centralize platform restriction checks

### DIFF
--- a/lib/dotfiles/migration.rb
+++ b/lib/dotfiles/migration.rb
@@ -27,10 +27,6 @@ class Dotfiles
       @dotfiles_dir, @home, @system = dotfiles_dir, home, system
     end
 
-    def allowed_on_platform?
-      platform_requirement_met?(:macos) && platform_requirement_met?(:debian)
-    end
-
     def up
       raise NotImplementedError, "Subclasses must implement #up"
     end
@@ -43,11 +39,6 @@ class Dotfiles
 
     def execute(command, quiet: true)
       @system.execute!(command, quiet: quiet)
-    end
-
-    def platform_requirement_met?(platform)
-      predicate = "#{platform}_only?"
-      !self.class.public_send(predicate) || @system.public_send("#{platform}?")
     end
   end
 end

--- a/lib/dotfiles/platform_restrictable.rb
+++ b/lib/dotfiles/platform_restrictable.rb
@@ -4,6 +4,10 @@ class Dotfiles
   # predicates. The includer's instances are expected to provide
   # `@system` (responding to #macos?/#debian?) for allowed_on_platform?.
   module PlatformRestrictable
+    def self.extended(base)
+      base.include InstanceMethods
+    end
+
     def macos_only
       @macos_only = true
     end
@@ -18,6 +22,13 @@ class Dotfiles
 
     def debian_only?
       @debian_only || false
+    end
+
+    module InstanceMethods
+      def allowed_on_platform?
+        (!self.class.macos_only? || @system.macos?) &&
+          (!self.class.debian_only? || @system.debian?)
+      end
     end
   end
 end

--- a/lib/dotfiles/step.rb
+++ b/lib/dotfiles/step.rb
@@ -129,12 +129,6 @@ class Dotfiles
       errors.dup
     end
 
-    def allowed_on_platform?
-      return false if self.class.macos_only? && !@system.macos?
-      return false if self.class.debian_only? && !@system.debian?
-      true
-    end
-
     private
 
     def debug(message)

--- a/test/dotfiles/platform_restrictable_test.rb
+++ b/test/dotfiles/platform_restrictable_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class PlatformRestrictableTest < Minitest::Test
+  def setup
+    super
+    @original_steps = Dotfiles::Step.class_variable_get(:@@steps).dup
+    @original_migrations = Dotfiles::Migration.class_variable_get(:@@migrations).dup
+  end
+
+  def teardown
+    Dotfiles::Step.class_variable_set(:@@steps, @original_steps)
+    Dotfiles::Migration.class_variable_set(:@@migrations, @original_migrations)
+    super
+  end
+
+  def test_unrestricted_instances_are_allowed
+    assert_platform_access
+  end
+
+  def test_macos_only_instances_are_allowed_only_on_macos
+    assert_platform_access(restrictions: [:macos], expected: false)
+    assert_platform_access(restrictions: [:macos], macos: true)
+  end
+
+  def test_debian_only_instances_are_allowed_only_on_debian
+    assert_platform_access(restrictions: [:debian], expected: false)
+    assert_platform_access(restrictions: [:debian], debian: true)
+  end
+
+  def test_dual_restricted_instances_require_both_platforms
+    assert_platform_access(restrictions: [:macos, :debian], expected: false)
+    assert_platform_access(restrictions: [:macos, :debian], macos: true, expected: false)
+    assert_platform_access(restrictions: [:macos, :debian], debian: true, expected: false)
+    assert_platform_access(restrictions: [:macos, :debian], macos: true, debian: true)
+  end
+
+  private
+
+  def assert_platform_access(restrictions: [], macos: false, debian: false, expected: true)
+    [Dotfiles::Step, Dotfiles::Migration].each do |base|
+      system = FakeSystemAdapter.new
+      system.stub_macos(macos)
+      system.stub_debian(debian)
+      instance = platform_restricted_instance(base, restrictions, system)
+
+      assert_equal expected, instance.allowed_on_platform?, base.name
+    end
+  end
+
+  def platform_restricted_instance(base, restrictions, system)
+    subclass = Class.new(base)
+    restrictions.each { |platform| subclass.public_send("#{platform}_only") }
+    return create_step(subclass, system: system, config: Object.new) if base == Dotfiles::Step
+
+    subclass.new(dotfiles_dir: @dotfiles_dir, home: @home, system: system)
+  end
+end


### PR DESCRIPTION
## Summary
- provide one shared instance-level platform predicate through `PlatformRestrictable`
- remove duplicate platform policy from steps and migrations
- cover unrestricted, macOS-only, Debian-only, and dual-restricted classes

Production code is 4 lines shorter; behavior is unchanged.

## Testing
- `bundle exec rake test`
- `mise run lint`
- independent subagent review