### PR TITLE
Deduplicate fake command results

### DIFF
--- a/test/support/fake_system_adapter.rb
+++ b/test/support/fake_system_adapter.rb
@@ -158,29 +158,12 @@ class FakeSystemAdapter
 
   def execute(command, quiet: true)
     @operations << [:execute, command, {quiet: quiet}]
-
-    stub = command_stub(command)
-    if stub
-      @exit_statuses << stub[:exit_status]
-      [stub[:output].strip, stub[:exit_status]]
-    else
-      @exit_statuses << 0
-      ["", 0]
-    end
+    command_result(command)
   end
 
   def execute!(command, quiet: true)
     @operations << [:execute!, command, {quiet: quiet}]
-
-    stub = command_stub(command)
-    if stub
-      @exit_statuses << stub[:exit_status]
-      raise "Command failed: #{Dotfiles::Command.display(command)}\nOutput: #{stub[:output]}" unless stub[:exit_status] == 0
-      [stub[:output].strip, stub[:exit_status]]
-    else
-      @exit_statuses << 0
-      ["", 0]
-    end
+    command_result(command, raise_on_failure: true)
   end
 
   def operation_count(operation_name)
@@ -214,6 +197,15 @@ class FakeSystemAdapter
   end
 
   private
+
+  def command_result(command, raise_on_failure: false)
+    stub = command_stub(command) || {output: "", exit_status: 0}
+    @exit_statuses << stub[:exit_status]
+    if raise_on_failure && stub[:exit_status] != 0
+      raise "Command failed: #{Dotfiles::Command.display(command)}\nOutput: #{stub[:output]}"
+    end
+    [stub[:output].strip, stub[:exit_status]]
+  end
 
   def command_stub(command)
     @command_outputs[command] ||

--- a/test/support/fake_system_adapter_test.rb
+++ b/test/support/fake_system_adapter_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class FakeSystemAdapterTest < Minitest::Test
+  def test_execute_and_execute_bang_return_the_unstubbed_default
+    [:execute, :execute!].each do |method|
+      adapter = FakeSystemAdapter.new
+
+      output, status = adapter.public_send(method, "missing", quiet: false)
+
+      assert_empty output
+      assert_equal 0, status
+      assert_equal [[method, "missing", {quiet: false}]], adapter.operations
+      assert_equal [0], adapter.exit_statuses
+    end
+  end
+
+  def test_execute_uses_normalized_lookup_and_returns_a_failed_result
+    @fake_system.stub_command("tool 2>/dev/null", "  failed\n", exit_status: 7)
+
+    output, status = @fake_system.execute(["tool"], quiet: false)
+
+    assert_equal "failed", output
+    assert_equal 7, status
+    assert_equal [[:execute, ["tool"], {quiet: false}]], @fake_system.operations
+    assert_equal [7], @fake_system.exit_statuses
+  end
+
+  def test_execute_bang_uses_normalized_lookup_and_returns_a_successful_result
+    @fake_system.stub_command("tool 2>/dev/null", "  done\n")
+
+    output, status = @fake_system.execute!(["tool"])
+
+    assert_equal "done", output
+    assert_equal 0, status
+    assert_equal [[:execute!, ["tool"], {quiet: true}]], @fake_system.operations
+    assert_equal [0], @fake_system.exit_statuses
+  end
+
+  def test_execute_bang_records_failure_before_raising_exact_error
+    @fake_system.stub_command(["tool", "two words"], "  failed\n", exit_status: 7)
+
+    error = assert_raises(RuntimeError) do
+      @fake_system.execute!(["tool", "two words"], quiet: false)
+    end
+
+    assert_equal "Command failed: tool two\\ words\nOutput:   failed\n", error.message
+    assert_equal [[:execute!, ["tool", "two words"], {quiet: false}]], @fake_system.operations
+    assert_equal [7], @fake_system.exit_statuses
+  end
+end


### PR DESCRIPTION
## Summary
- share command-stub result handling between `execute` and `execute!`
- preserve operation recording, output normalization, statuses, and exact errors
- add focused behavioral coverage for the test adapter

The duplicated support implementation is 8 lines shorter.

## Testing
- `bundle exec rake test`
- `mise run lint`
- independent subagent review