### PR TITLE
Ignore pi subagent artifacts globally

### DIFF
--- a/files/home/.gitignore
+++ b/files/home/.gitignore
@@ -16,5 +16,6 @@ node_modules/
 .checkouts/
 .pi/agents/
 .pi/todos/
+.pi-subagents/
 .factory
 


### PR DESCRIPTION
## Summary

- add `.pi-subagents/` to the managed global Git ignore file
- prevent local subagent transcripts and artifacts from appearing as untracked files or being scanned as repository content

## Testing

- verified with `git check-ignore`
- `mise run test` (371 runs, 915 assertions)