### PR TITLE
Show sudo banner only before authentication prompts

### DIFF
--- a/lib/dotfiles/step/sudoable.rb
+++ b/lib/dotfiles/step/sudoable.rb
@@ -1,6 +1,8 @@
 class Dotfiles
   class Step
     module Sudoable
+      SUDO_MUTEX = Mutex.new
+
       def should_run?
         return false if ci_or_noninteractive?
         super
@@ -25,8 +27,15 @@ class Dotfiles
       end
 
       def execute_with_sudo(command)
-        display_sudo_warning(command)
-        run_command(Dotfiles::Command.prepend(command, "sudo"), quiet: false)
+        SUDO_MUTEX.synchronize do
+          display_sudo_warning(command) if sudo_authentication_required?
+          run_command(Dotfiles::Command.prepend(command, "sudo"), quiet: false)
+        end
+      end
+
+      def sudo_authentication_required?
+        output, status = run_command(Dotfiles::Command.argv("sudo", "-n", "-v"), quiet: true)
+        status != 0 && output.include?("password is required")
       end
 
       def display_sudo_warning(command)

--- a/test/dotfiles/step/sudoable_test.rb
+++ b/test/dotfiles/step/sudoable_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class SudoableTest < StepTestCase
+  step_class Dotfiles::Step::ProtectFilesStep
+
+  def setup
+    super
+    @fake_system.stub_macos
+    @file = step.send(:pi_extension_files).first
+    @fake_system.stub_file_content(@file, "extension content")
+  end
+
+  def test_skips_admin_warning_when_sudo_credentials_are_cached
+    @fake_system.stub_command(["sudo", "-n", "-v"], "", 0)
+
+    step.run
+
+    refute admin_warning_displayed?
+  end
+
+  def test_displays_admin_warning_when_sudo_will_prompt
+    @fake_system.stub_command(["sudo", "-n", "-v"], "sudo: a password is required", 1)
+
+    step.run
+
+    assert admin_warning_displayed?
+  end
+
+  def test_skips_admin_warning_when_sudo_validation_fails_for_another_reason
+    @fake_system.stub_command(["sudo", "-n", "-v"], "sudo: command not found", 127)
+
+    step.run
+
+    refute admin_warning_displayed?
+  end
+
+  private
+
+  def admin_warning_displayed?
+    @fake_system.operations.any? do |operation, command, _options|
+      operation == :execute && command.include?("🔒 Admin Privileges Required")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- probe the sudo authentication cache non-interactively before displaying the admin warning
- serialize sudo checks and commands so parallel steps do not show duplicate warnings
- cover cached credentials, required passwords, and unrelated sudo validation failures

## Tests
- `bundle exec rake test`
- `bundle exec standardrb`
- `bundle exec rake flog flay`
- custom perceived-complexity check
- staged gitleaks scan

## Notes
The local pre-commit secrets task scans the entire working tree and was blocked by an unrelated pre-existing untracked `files/home/.claude/skills/.system/` directory. The staged gitleaks scan passed, and all other checks were run directly.