### PR TITLE
Improve architecture review reports

### DIFF
--- a/files/home/.claude/skills/improve-codebase-architecture/HTML-REPORT.md
+++ b/files/home/.claude/skills/improve-codebase-architecture/HTML-REPORT.md
@@ -1,6 +1,6 @@
 # HTML Report Format
 
-The architectural review is rendered as a single self-contained HTML file in the OS temp directory. Tailwind and Mermaid both come from CDNs. Mermaid handles graph-shaped diagrams reliably; hand-built divs and inline SVG handle the more editorial visuals (mass diagrams, cross-sections). Mix the two — don't lean on Mermaid for everything, it'll start to look generic.
+Render the architecture review as one self-contained HTML file in the OS temp directory. Use Tailwind via CDN and highlight.js via CDN. Do not use Mermaid, SVG, or architecture diagrams: actual and proposed code carry the argument.
 
 ## Scaffold
 
@@ -9,22 +9,23 @@ The architectural review is rendered as a single self-contained HTML file in the
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Architecture review — {{repo name}}</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script type="module">
-      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
-      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github-dark.min.css" />
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/highlight.min.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", () => typeof hljs === "undefined" || hljs.highlightAll());
     </script>
     <style>
-      /* small custom layer for things Tailwind doesn't cover cleanly:
-         dashed seam lines, hand-drawn-feeling arrow heads, etc. */
-      .seam { stroke-dasharray: 4 4; }
-      .leak { stroke: #dc2626; }
-      .deep { background: linear-gradient(135deg, #0f172a, #1e293b); }
+      html, body { max-width: 100%; overflow-x: hidden; }
+      main, section, article, figure { min-width: 0; max-width: 100%; }
+      pre { box-sizing: border-box; tab-size: 2; width: 100%; }
+      .code-scroll { color: #e2e8f0; max-width: 100%; scrollbar-width: thin; }
     </style>
   </head>
   <body class="bg-stone-50 text-slate-900 font-sans">
-    <main class="max-w-5xl mx-auto px-6 py-12 space-y-12">
+    <main class="max-w-6xl mx-auto px-6 py-12 space-y-12">
       <header>...</header>
       <section id="candidates" class="space-y-10">...</section>
       <section id="top-recommendation">...</section>
@@ -33,91 +34,125 @@ The architectural review is rendered as a single self-contained HTML file in the
 </html>
 ```
 
+Tailwind and highlight.js are the only scripts. Keep the rest static. Guard the highlight call so a CDN failure does not raise an error, and keep the report readable when highlight.js is unavailable.
+
 ## Header
 
-Repo name, date, and a compact legend: solid box = module, dashed line = seam, red arrow = leakage, thick dark box = deep module. No introduction paragraph — straight into the candidates.
+Show the repo name, date, and a compact legend:
+
+- `Current code` — exact repository excerpt
+- `Proposed sketch` — discussion code that may not compile
+- `Test surface` — caller or test code showing the seam
+
+If `CONTEXT.md` is absent, say so in one muted line. Follow the header with a compact **At a glance** section: state the top recommendation first, then give one short bullet per candidate. Do not add an introduction paragraph.
 
 ## Candidate card
 
-The diagrams carry the weight. Prose is sparse, plain, and uses the glossary terms (from the `/codebase-design` skill) without ceremony.
+Each candidate is one `<article>` with:
 
-Each candidate is one `<article>`:
+1. **Title** — name the ownership change, such as “Let Step execution own lifecycle state.”
+2. **Badge row** — recommendation strength (`Strong` = emerald, `Worth exploring` = amber, `Speculative` = slate) and dependency category (`in-process`, `local-substitutable`, `ports & adapters`, `mock`).
+3. **Files** — monospaced paths with `break-all` so long paths do not widen the mobile page.
+4. **What happens today** — two or three sentences narrating the current call path and friction. Do not add a generic `Problem` heading.
+5. **Current code** — an exact, representative repository excerpt with a file-path caption.
+6. **Proposed direction** — two or three sentences naming the implementation ownership that moves behind the seam.
+7. **Proposed code** — concrete code or pseudocode labeled `Proposed sketch`.
+8. **Caller or test change** — optional second code pair showing how the interface or test surface shrinks.
+9. **Why this is deeper** — one compact paragraph using interface, depth, seam, locality, leverage, and test surface where relevant.
+10. **ADR callout** — only when the proposal conflicts with or materially resolves tension in an ADR.
 
-- **Title** — short, names the deepening (e.g. "Collapse the Order intake pipeline").
-- **Badge row** — recommendation strength (`Strong` = emerald, `Worth exploring` = amber, `Speculative` = slate), plus a tag for the dependency category (`in-process`, `local-substitutable`, `ports & adapters`, `mock`).
-- **Files** — monospaced list, `font-mono text-sm`.
-- **Before / After diagram** — the centrepiece. Two columns, side by side. See patterns below.
-- **Problem** — one sentence. What hurts.
-- **Solution** — one sentence. What changes.
-- **Wins** — bullets, ≤6 words each. e.g. "Tests hit one interface", "Pricing logic stops leaking", "Delete 4 shallow wrappers".
-- **ADR callout** (if applicable) — one line in an amber-tinted box.
+Do not render separate `Problem`, `Solution`, `Benefits`, or `Deletion test` sections. The narrative and code should make those points concrete.
 
-No paragraphs of explanation. If the diagram needs a paragraph to be understood, redraw the diagram.
+## Code presentation
 
-## Diagram patterns
+### Side-by-side current and proposed code
 
-Pick the pattern that fits the candidate. Mix them. Don't make every diagram look the same — variety is part of the point.
-
-### Mermaid graph (the workhorse for dependencies / call flow)
-
-Use a Mermaid `flowchart` or `graph` when the point is "X calls Y calls Z, and look at the mess." Wrap it in a Tailwind-styled card so it doesn't feel parachuted in. Style with classDef to colour leakage edges red and the deep module dark. Sequence diagrams work well for "before: 6 round-trips; after: 1."
+Use this as the default centrepiece:
 
 ```html
-<div class="rounded-lg border border-slate-200 bg-white p-4">
-  <pre class="mermaid">
-    flowchart LR
-      A[OrderHandler] --> B[OrderValidator]
-      B --> C[OrderRepo]
-      C -.leak.-> D[PricingClient]
-      classDef leak stroke:#dc2626,stroke-width:2px;
-      class C,D leak
-  </pre>
+<div class="grid lg:grid-cols-2 gap-5">
+  <figure class="rounded-xl overflow-hidden border border-slate-300 bg-slate-950">
+    <figcaption class="flex justify-between bg-slate-900 px-4 py-3 text-xs"><span class="font-semibold text-rose-300">Current code</span><code class="break-all text-slate-400">lib/orders/runner.rb</code></figcaption>
+    <pre class="code-scroll overflow-x-auto p-4 text-sm leading-6"><code class="language-ruby">...</code></pre>
+  </figure>
+  <figure class="rounded-xl overflow-hidden border border-indigo-300 bg-slate-950">
+    <figcaption class="flex justify-between bg-indigo-950 px-4 py-3 text-xs"><span class="font-semibold text-indigo-200">Proposed sketch</span><code class="break-all text-indigo-300">lib/orders/execution.rb</code></figcaption>
+    <pre class="code-scroll overflow-x-auto p-4 text-sm leading-6"><code class="language-ruby">...</code></pre>
+  </figure>
 </div>
 ```
 
-### Hand-built boxes-and-arrows (when Mermaid's layout fights you)
+Escape HTML characters inside code. Keep excerpts short enough to compare without vertical hunting, usually 8–30 lines.
 
-Modules as `<div>`s with borders and labels. Arrows as inline SVG `<line>` or `<path>` elements positioned absolutely over a relative container. Reach for this when you want the "after" diagram to feel like one thick-bordered deep module with greyed-out internals — Mermaid won't render that with the right weight.
+### Exactness rules
 
-### Cross-section (good for layered shallowness)
+- Current excerpts must exist in the repository. Preserve names and meaningful control flow.
+- Add a path caption to every current excerpt.
+- Use `# ...` or the language’s normal omission marker when trimming unrelated code.
+- Never silently rewrite current code to strengthen the argument.
+- Proposed code may be pseudocode or incomplete, but must use plausible project names and language idioms.
+- Start every non-current excerpt label with `Proposed`, such as `Proposed sketch`, `Proposed test surface`, or `Proposed caller change`; do not present it as a ready patch.
+- Show dependencies and ownership explicitly instead of hiding them behind placeholders such as `do_the_thing`.
+- Assign every block an explicit highlight.js class. Use `language-ruby` for `.rb`, `language-bash` for shell scripts and extensionless shell entry points, `language-yaml` for `.yml`/`.yaml`, `language-typescript` for `.ts`/`.tsx`, `language-javascript` for `.js`/`.jsx`, and `language-plaintext` when uncertain.
+- Infer extensionless files from their shebang or contents; for example, `bin/dotf` is `language-bash`.
+- Use the same language class for current and proposed versions of the same module.
 
-Stack horizontal bands (`h-12 border-l-4`) to show layers a call passes through. Before: 6 thin layers each doing nothing. After: 1 thick band labelled with the consolidated responsibility.
+### Caller or test changes
 
-### Mass diagram (good for "interface as wide as implementation")
+A candidate is easier to assess when the report shows leverage at a real call site. Prefer one small excerpt such as:
 
-Two rectangles per module — one for interface surface area, one for implementation. Before: interface rectangle is nearly as tall as the implementation rectangle (shallow). After: interface rectangle is short, implementation rectangle is tall (deep).
+- a caller losing ordering or configuration knowledge
+- a test replacing private-state surgery with the public interface
+- several call sites collapsing into one module
+- an adapter fake becoming smaller
 
-### Call-graph collapse
+Label current repository excerpts `Current test surface` or `Current caller`. Label discussion code `Proposed test surface` or `Proposed caller change`.
 
-Before: a tree of function calls rendered as nested boxes. After: the same tree collapsed into one box, with the now-internal calls shown faded inside it.
+## Narrative guidance
+
+Lead the reader through the code in this order:
+
+1. “Today, this caller must know…”
+2. Show the exact code.
+3. “Move that ownership into…”
+4. Show the proposed sketch.
+5. “The caller/test then becomes…”
+6. Explain why the resulting module is deeper.
+
+Keep paragraphs short. Code should occupy more visual area than prose.
 
 ## Style guidance
 
-- Lean editorial, not corporate-dashboard. Generous whitespace. Serif optional for headings (`font-serif` works well with stone/slate).
-- Colour sparingly: one accent (emerald or indigo) plus red for leakage and amber for warnings.
-- Keep diagrams ~320px tall so before/after sits comfortably side by side without scrolling.
-- Use `text-xs uppercase tracking-wider` for module labels inside diagrams — they should read as schematic, not as UI.
-- The only scripts are the Tailwind CDN and the Mermaid ESM import. The report is otherwise static — no app code, no interactivity beyond Mermaid's own rendering.
+- Lean editorial, not a corporate dashboard.
+- Use generous whitespace and a serif heading if desired.
+- Use dark code panels with restrained rose for current friction and indigo/emerald for proposed code.
+- Use line wrapping only for prose; code scrolls horizontally.
+- Keep highlight.js styling subordinate to the report: use one dark theme and do not add per-token custom colours.
+- Preserve readable dark code panels before highlight.js loads or if its CDN is unavailable.
+- On narrow screens, stack current and proposed code; on wide screens, show them side by side.
+- Constrain the page and its main structural elements to the viewport, give code figures `min-width: 0`, make code blocks fill their figure, and allow file paths to break. The page must not scroll horizontally on a mobile viewport; only code blocks may scroll horizontally.
 
-## Top recommendation section
+## Top recommendation
 
-One larger card. Candidate name, one sentence on why, anchor link to its card. That's it.
+State the top recommendation in the **At a glance** section near the top. The final recommendation card may repeat only its name, one sentence explaining its leverage, and an anchor link. Do not repeat its code.
 
-## Tone
+## Readability gate
 
-Plain English, concise — but the architectural nouns and verbs come straight from the `/codebase-design` skill. Concision is not an excuse to drift.
+Before opening the report, apply the `/readability` skill as required by `SKILL.md`. Audit extracted user-facing prose, not source code or HTML markup. Every deterministic audit check must report `PASS` at the default grade target; warnings also block presentation. Then inspect the rendered page for scanning, mobile stacking, code legibility, and working syntax highlighting.
+
+## Tone and vocabulary
+
+Plain English, concise, and concrete. Use the `/codebase-design` vocabulary consistently.
 
 **Use exactly:** module, interface, implementation, depth, deep, shallow, seam, adapter, leverage, locality.
 
-**Never substitute:** component, service, unit (for module) · API, signature (for interface) · boundary (for seam) · layer, wrapper (for module, when you mean module).
+**Never substitute:** component, service, unit (for module) · API, signature (for interface) · boundary (for seam) · layer or wrapper (for module).
 
-**Phrasings that fit the style:**
+Good phrasing:
 
-- "Order intake module is shallow — interface nearly matches the implementation."
-- "Pricing leaks across the seam."
-- "Deepen: one interface, one place to test."
-- "Two adapters justify the seam: HTTP in prod, in-memory in tests."
+- “Today, Runner must know that checking completion also mutates errors.”
+- “Move lifecycle state behind the Step execution seam.”
+- “The proposed sketch gives tests the same interface callers use.”
+- “Locality improves because privilege policy no longer depends on mixin order.”
 
-**Wins bullets** name the gain in glossary terms: *"locality: bugs concentrate in one module"*, *"leverage: one interface, N call sites"*, *"interface shrinks; implementation absorbs the wrappers"*. Don't write *"easier to maintain"* or *"cleaner code"* — those terms aren't in the glossary and don't earn their place.
-
-No hedging, no throat-clearing, no "it's worth noting that…". If a sentence could be a bullet, make it a bullet. If a bullet could be cut, cut it. If a term isn't in the `/codebase-design` glossary, reach for one that is before inventing a new one.
+Avoid generic claims such as “cleaner,” “more maintainable,” or “better separation.” Point to the code that creates locality or leverage.

--- a/files/home/.claude/skills/improve-codebase-architecture/SKILL.md
+++ b/files/home/.claude/skills/improve-codebase-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: improve-codebase-architecture
-description: Scan a codebase for deepening opportunities, present them as a visual HTML report, then grill through whichever one you pick.
+description: Scan a codebase for deepening opportunities, present them as a code-centered HTML report with current and proposed code, then grill through whichever one you pick.
 license: "MIT; copyright Matt Pocock; see ../matt-pocock-skills-LICENSE.txt"
 source: https://github.com/mattpocock/skills/tree/main/skills/engineering/improve-codebase-architecture
 disable-model-invocation: true
@@ -33,18 +33,22 @@ Apply the **deletion test** to anything you suspect is shallow: would deleting i
 
 ### 2. Present candidates as an HTML report
 
-Write a self-contained HTML file to the OS temp directory so nothing lands in the repo. Resolve the temp dir from `$TMPDIR`, falling back to `/tmp` (or `%TEMP%` on Windows), and write to `<tmpdir>/architecture-review-<timestamp>.html` so each run gets a fresh file. Open it for the user — `xdg-open <path>` on Linux, `open <path>` on macOS, `start <path>` on Windows — and tell them the absolute path.
+Write a self-contained HTML file to the OS temp directory so nothing lands in the repo. Resolve the temp dir from `$TMPDIR`, falling back to `/tmp` (or `%TEMP%` on Windows), and write to `<tmpdir>/architecture-review-<timestamp>.html` so each run gets a fresh file. Do not open or present it until the readability pass in step 3 succeeds.
 
-The report uses **Tailwind via CDN** for layout and styling, and **Mermaid via CDN** for diagrams where a graph/flow/sequence reliably communicates the structure. Mix Mermaid with hand-crafted CSS/SVG visuals — use Mermaid when relationships are graph-shaped (call graphs, dependencies, sequences), and hand-built divs/SVG when you want something more editorial (mass diagrams, cross-sections, collapse animations). Each candidate gets a **before/after visualisation**. Be visual.
+The report uses **Tailwind via CDN** for layout and **highlight.js via CDN** for syntax highlighting. It is code-centered: explain each candidate by narrating a concrete refactor and showing real current code beside proposed code. Assign an explicit highlight.js language class to every code block instead of relying on automatic detection. Do not use Mermaid, SVG, architecture diagrams, or generic problem/solution/deletion-test sections.
 
 For each candidate, render a card with:
 
 - **Files** — which files/modules are involved
-- **Problem** — why the current architecture is causing friction
-- **Solution** — plain English description of what would change
-- **Benefits** — explained in terms of locality and leverage, and how tests would improve
-- **Before / After diagram** — side-by-side, custom-drawn, illustrating the shallowness and the deepening
+- **What happens today** — a short narrative grounded in an exact excerpt from the current code
+- **Current code** — a small, representative excerpt copied from the repository and labeled with its file path; use ellipses only when omission is clear
+- **Proposed direction** — a short narrative that names what ownership moves and why
+- **Proposed code** — a concrete sketch using the project's language and names; pseudocode and non-compiling sketches are allowed, but label them `Proposed sketch`
+- **Caller or test change** — when useful, show how a real caller or test becomes smaller or moves to the new interface
+- **Why this is deeper** — a compact explanation in terms of interface, locality, leverage, seam, and test surface
 - **Recommendation strength** — one of `Strong`, `Worth exploring`, `Speculative`, rendered as a badge
+
+Prefer two or three focused code excerpts over a large synthetic rewrite. Proposed code must be specific enough to discuss method ownership, dependencies, and the test surface; avoid placeholder boxes or prose-only abstractions.
 
 End the report with a **Top recommendation** section: which candidate you'd tackle first and why.
 
@@ -52,11 +56,24 @@ End the report with a **Top recommendation** section: which candidate you'd tack
 
 **ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly in the card (e.g. a warning callout: _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
 
-See [HTML-REPORT.md](HTML-REPORT.md) for the full HTML scaffold, diagram patterns, and styling guidance.
+See [HTML-REPORT.md](HTML-REPORT.md) for the full HTML scaffold, code-presentation patterns, and styling guidance.
 
-Do NOT propose interfaces yet. After the file is written, ask the user: "Which of these would you like to explore?"
+The proposed code is a discussion sketch, not an implementation plan. Do not edit the project.
 
-### 3. Grilling loop
+### 3. Apply a readability pass
+
+Run the `/readability` skill against the finished report before presenting it. The audience is a maintainer choosing which refactor to discuss; their task is to compare current and proposed code quickly.
+
+- Front-load a compact **At a glance** section with the top recommendation and one short bullet per candidate.
+- Keep headings descriptive, paragraphs short, and labels consistent. Preserve exact current-code excerpts during prose edits.
+- Extract the report's user-facing prose to `<tmpdir>/architecture-review-<timestamp>-prose.md`. Exclude code samples, scripts, styles, HTML attributes, file paths, and badge labels; preserve headings and lists.
+- Run the readability skill's bundled `readability_audit.rb` against that prose file with its default grade target of 10.
+- Fix every warning and failed check in both the HTML report and extracted prose, then rerun the audit until every check reports `PASS`. Required architecture and domain terms may remain, but simplify the surrounding sentences rather than skipping a check.
+- Check the rendered HTML for scanning, mobile stacking, code legibility, and working syntax highlighting. Do not treat a passing script as sufficient by itself.
+
+After the pass succeeds, open the HTML file for the user — `xdg-open <path>` on Linux, `open <path>` on macOS, `start <path>` on Windows — tell them the absolute path, briefly summarize the readability changes, and ask: "Which of these would you like to explore?"
+
+### 4. Grilling loop
 
 Once the user picks a candidate, run the `/grilling` skill to walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
 


### PR DESCRIPTION
## Summary

- replace diagram-led architecture reports with current and proposed code excerpts
- add syntax highlighting, mobile-safe code panels, and readable fallbacks
- require a readability audit and rendered-page check before presenting reports

## Validation

- `python3 files/home/.claude/skills/skill-creator/scripts/quick_validate.py files/home/.claude/skills/improve-codebase-architecture`
- pre-commit hooks, including 379 tests / 918 assertions
- independent reviewer pass with findings addressed