### PR TITLE
Count thinking and tool-call tokens in toksec

### DIFF
--- a/files/home/.pi/agent/extensions/toksec/index.ts
+++ b/files/home/.pi/agent/extensions/toksec/index.ts
@@ -1,7 +1,13 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { formatStatus } from "./format.ts";
 import { addSample, currentModel, rebuildStats, sameModel, zeroStats } from "./samples.ts";
-import { isDeltaEvent, isFinalAssistantMessage, isOutputEvent, outputTokensFromMessage } from "./stream_events.ts";
+import {
+	charsFromMessage,
+	deltaCharsFromEvent,
+	isFinalAssistantMessage,
+	isOutputEvent,
+	outputTokensFromMessage,
+} from "./stream_events.ts";
 import { CUSTOM_TYPE, STATUS_KEY, type ActiveMeasurement, type AggregateStats, type ModelRef, type ToksecEntry } from "./types.ts";
 
 function updateStatus(ctx: ExtensionContext, stats: AggregateStats): void {
@@ -13,12 +19,14 @@ function createSample(message: unknown, measurement: ActiveMeasurement): ToksecE
 	const firstOutputAt = measurement.firstOutputAt;
 	if (!firstOutputAt) return undefined;
 
+	const observedChars = Math.max(measurement.observedChars, charsFromMessage(message));
+
 	return {
 		version: 1,
 		kind: "sample",
 		provider: measurement.model.provider,
 		modelId: measurement.model.id,
-		outputTokens: outputTokensFromMessage(message, measurement.deltaChars),
+		outputTokens: outputTokensFromMessage(message, observedChars),
 		generationMs: Date.now() - firstOutputAt,
 		ttftMs: firstOutputAt - measurement.requestStartedAt,
 		timestamp: new Date().toISOString(),
@@ -49,7 +57,11 @@ export default function toksecExtension(pi: ExtensionAPI) {
 		const model = currentModel(ctx) ?? selectedModel;
 		if (!model) return;
 
-		active = { model, requestStartedAt: pendingRequestStartedAt ?? Date.now(), deltaChars: 0 };
+		active = {
+			model,
+			requestStartedAt: pendingRequestStartedAt ?? Date.now(),
+			observedChars: 0,
+		};
 		pendingRequestStartedAt = undefined;
 	});
 
@@ -60,9 +72,14 @@ export default function toksecExtension(pi: ExtensionAPI) {
 		if (!isOutputEvent(assistantEvent)) return;
 
 		active.firstOutputAt ??= Date.now();
-		if (isDeltaEvent(assistantEvent) && typeof assistantEvent.delta === "string") {
-			active.deltaChars += assistantEvent.delta.length;
-		}
+
+		// Count the whole assistant payload (text + thinking + tool calls), not just
+		// text deltas. Prefer the running partial message; also accumulate raw deltas
+		// for providers that omit partial content on some events.
+		active.observedChars = Math.max(
+			active.observedChars + deltaCharsFromEvent(assistantEvent),
+			charsFromMessage(event.message),
+		);
 	});
 
 	pi.on("message_end", async (event, ctx) => {
@@ -72,6 +89,13 @@ export default function toksecExtension(pi: ExtensionAPI) {
 
 		if (!isFinalAssistantMessage(event.message)) return updateStatus(ctx, stats);
 		if (!sameModel(measurement.model, selectedModel ?? currentModel(ctx))) return updateStatus(ctx, stats);
+
+		// Non-streaming completions skip message_update; still count the final payload.
+		const finalChars = charsFromMessage(event.message);
+		if (!measurement.firstOutputAt && finalChars > 0) {
+			measurement.firstOutputAt = Date.now();
+			measurement.observedChars = Math.max(measurement.observedChars, finalChars);
+		}
 
 		const sample = createSample(event.message, measurement);
 		if (!sample) return updateStatus(ctx, stats);

--- a/files/home/.pi/agent/extensions/toksec/stream_events.ts
+++ b/files/home/.pi/agent/extensions/toksec/stream_events.ts
@@ -1,33 +1,90 @@
-export function isDeltaEvent(event: unknown): event is { type: string; delta?: string } {
-	if (!event || typeof event !== "object") return false;
-	const type = (event as { type?: unknown }).type;
-	return typeof type === "string" && type.endsWith("_delta");
+const OUTPUT_EVENT_TYPES = new Set([
+	"text_start",
+	"text_delta",
+	"text_end",
+	"thinking_start",
+	"thinking_delta",
+	"thinking_end",
+	"toolcall_start",
+	"toolcall_delta",
+	"toolcall_end",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object";
+}
+
+function estimateTokensFromChars(chars: number): number {
+	return Math.max(0, Math.ceil(chars / 4));
+}
+
+function jsonLength(value: unknown): number {
+	if (typeof value === "string") return value.length;
+	try {
+		return JSON.stringify(value ?? {}).length;
+	} catch {
+		return String(value).length;
+	}
+}
+
+/** Characters attributable to one assistant content block (text, thinking, or tool call). */
+export function charsFromContentBlock(block: unknown): number {
+	if (!isRecord(block)) return 0;
+
+	switch (block.type) {
+		case "text":
+			return typeof block.text === "string" ? block.text.length : 0;
+		case "thinking":
+			return typeof block.thinking === "string" ? block.thinking.length : 0;
+		case "toolCall": {
+			const name = typeof block.name === "string" ? block.name : "";
+			return name.length + jsonLength(block.arguments);
+		}
+		default:
+			return 0;
+	}
+}
+
+/** Full assistant payload size: visible text, thinking, and tool-call arguments. */
+export function charsFromMessage(message: unknown): number {
+	if (!isRecord(message) || !Array.isArray(message.content)) return 0;
+	return message.content.reduce<number>((total, block) => total + charsFromContentBlock(block), 0);
+}
+
+/** Stream delta characters for text, thinking, and tool-call JSON chunks. */
+export function deltaCharsFromEvent(event: unknown): number {
+	if (!isRecord(event) || typeof event.type !== "string") return 0;
+	if (!event.type.endsWith("_delta")) return 0;
+	return typeof event.delta === "string" ? event.delta.length : 0;
 }
 
 export function isOutputEvent(event: unknown): boolean {
-	if (!event || typeof event !== "object") return false;
-	const type = (event as { type?: unknown }).type;
-	return (
-		type === "text_start" ||
-		type === "text_delta" ||
-		type === "text_end" ||
-		type === "thinking_start" ||
-		type === "thinking_delta" ||
-		type === "thinking_end" ||
-		type === "toolcall_start" ||
-		type === "toolcall_delta" ||
-		type === "toolcall_end"
-	);
+	if (!isRecord(event) || typeof event.type !== "string") return false;
+	return OUTPUT_EVENT_TYPES.has(event.type);
 }
 
+/**
+ * Prefer provider usage. When a provider reports reasoning outside `output`
+ * (reasoning > output), add them. Fall back to content/stream char estimates so
+ * thinking and tool calls still count when usage is missing.
+ */
 export function outputTokensFromMessage(message: unknown, fallbackChars: number): number {
-	const usage = (message as { usage?: { output?: unknown } } | undefined)?.usage;
-	if (typeof usage?.output === "number" && usage.output > 0) return usage.output;
-	return Math.max(0, Math.ceil(fallbackChars / 4));
+	const usage = isRecord(message) && isRecord(message.usage) ? message.usage : undefined;
+	const output = typeof usage?.output === "number" && Number.isFinite(usage.output) ? usage.output : undefined;
+	const reasoning =
+		typeof usage?.reasoning === "number" && Number.isFinite(usage.reasoning) ? usage.reasoning : undefined;
+
+	if (output !== undefined && output > 0) {
+		// Most providers nest reasoning inside output; a few report them separately.
+		return reasoning !== undefined && reasoning > output ? output + reasoning : output;
+	}
+	if (reasoning !== undefined && reasoning > 0) return reasoning;
+
+	const contentChars = Math.max(charsFromMessage(message), fallbackChars);
+	return estimateTokensFromChars(contentChars);
 }
 
 export function isFinalAssistantMessage(message: unknown): boolean {
-	if (!message || typeof message !== "object") return false;
-	const msg = message as { role?: unknown; stopReason?: unknown };
-	return msg.role === "assistant" && msg.stopReason !== "error" && msg.stopReason !== "aborted";
+	if (!isRecord(message)) return false;
+	return message.role === "assistant" && message.stopReason !== "error" && message.stopReason !== "aborted";
 }

--- a/files/home/.pi/agent/extensions/toksec/types.ts
+++ b/files/home/.pi/agent/extensions/toksec/types.ts
@@ -11,7 +11,8 @@ export type ActiveMeasurement = {
 	model: ModelRef;
 	requestStartedAt: number;
 	firstOutputAt?: number;
-	deltaChars: number;
+	/** Observed assistant output chars across text, thinking, and tool calls. */
+	observedChars: number;
 };
 
 export type AggregateStats = {


### PR DESCRIPTION
## Summary
- Measure tok/s from the full assistant payload (text + thinking + tool calls), not just stream delta strings.
- Prefer provider `usage.output`, and add `usage.reasoning` when a provider reports reasoning outside output.
- Fall back to final message content for non-streaming / sparse streams so tool-only and thinking-heavy turns still sample.

## Test plan
- [x] Local node sanity checks for content/delta/usage token math
- [x] `bundle exec rake test` (347 runs)
- [ ] Restart pi and confirm status updates on a thinking + tool-call turn