### PR TITLE
Configure subagent thinking levels

### DIFF
--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -32,6 +32,12 @@
     "agentOverrides": {
       "reviewer": {
         "thinking": "xhigh"
+      },
+      "oracle": {
+        "thinking": "xhigh"
+      },
+      "worker": {
+        "thinking": "medium"
       }
     }
   },

--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -36,6 +36,9 @@
       "oracle": {
         "thinking": "xhigh"
       },
+      "advisor": {
+        "thinking": "xhigh"
+      },
       "worker": {
         "thinking": "medium"
       }


### PR DESCRIPTION
## Summary
- run the oracle and its advisor compatibility alias with xhigh thinking
- run the worker subagent with medium thinking

## Validation
- `jq empty files/home/.pi/agent/settings.json`
- pre-commit hooks
- verified the live advisor configuration resolves to xhigh