### PR TITLE
Add Matt Pocock's wait-what skill

### DIFF
--- a/files/home/.claude/skills/wait-what/SKILL.md
+++ b/files/home/.claude/skills/wait-what/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: wait-what
+description: Stop. That last message did not land — re-pitch it.
+license: "MIT; copyright Matt Pocock; see ../matt-pocock-skills-LICENSE.txt"
+source: https://github.com/mattpocock/skills/tree/main/skills/productivity/wait-what
+disable-model-invocation: true
+---
+
+Wait — I don't understand where you've got to here. Re-pitch that: give me a little bit of context, talk in ASD-STE100 Simplified Technical English, and use the ubiquitous language from `CONTEXT.md`.

--- a/files/home/.claude/skills/wait-what/SKILL.md
+++ b/files/home/.claude/skills/wait-what/SKILL.md
@@ -6,4 +6,4 @@ source: https://github.com/mattpocock/skills/tree/main/skills/productivity/wait-
 disable-model-invocation: true
 ---
 
-Wait — I don't understand where you've got to here. Re-pitch that: give me a little bit of context, talk in ASD-STE100 Simplified Technical English, and use the ubiquitous language from `CONTEXT.md`.
+Wait — I don't understand where you've got to here. Re-pitch that: give me a little bit of context, talk in ASD-STE100 Simplified Technical English, and speak at approximately a 10th grade reading level.


### PR DESCRIPTION
## Summary
- add Matt Pocock's `wait-what` productivity skill
- retain the upstream source and MIT attribution

## Validation
- `python3 files/home/.claude/skills/skill-creator/scripts/quick_validate.py files/home/.claude/skills/wait-what`
- `mise run lint:skills`
- `mise run test`