### PR TITLE
Make Aube downloads resilient in CI

### DIFF
--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -103,6 +103,7 @@ jobs:
         DEBUG: true
         CI: true
         NONINTERACTIVE: true
+        AUBE_DISABLE_TARBALL_STREAM: "1"
         GITHUB_TOKEN: ${{ github.token }}
         MISE_CI_TOOLS: "gum@0.17.0,github:jdx/aube@1.36.0,npm:@earendil-works/pi-coding-agent@0.83.0,fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
         BREW_CI_PACKAGES: "duti"
@@ -201,6 +202,7 @@ jobs:
         DEBUG: true
         CI: true
         NONINTERACTIVE: true
+        AUBE_DISABLE_TARBALL_STREAM: "1"
         GITHUB_TOKEN: ${{ github.token }}
         MISE_CI_TOOLS: "gum@0.17.0,github:jdx/aube@1.36.0,npm:@earendil-works/pi-coding-agent@0.83.0,fzf@latest,aqua:fish-shell/fish-shell@4.8.1"
         BREW_CI_PACKAGES: "duti"
@@ -218,6 +220,7 @@ jobs:
           DEBUG="${DEBUG}" \
           CI="${CI}" \
           NONINTERACTIVE="${NONINTERACTIVE}" \
+          AUBE_DISABLE_TARBALL_STREAM="${AUBE_DISABLE_TARBALL_STREAM}" \
           GITHUB_TOKEN="${GITHUB_TOKEN}" \
           MISE_CI_TOOLS="${MISE_CI_TOOLS}" \
           BREW_CI_PACKAGES="${BREW_CI_PACKAGES}" \


### PR DESCRIPTION
## Summary

- disable Aube tarball streaming in integration tests
- forward the setting into the non-admin macOS test environment
- use Aube’s buffered download path, which retries response-body read failures

## Why

Most recent main-branch integration flakes were mid-stream npm response decoding failures. Aube’s buffered path retries those failures, while its tarball streaming path currently propagates them immediately.

## Validation

- YAML syntax parsed successfully
- `git diff --check` passed