### PR TITLE
Replace skill lint with deterministic review checks

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -62,7 +62,7 @@ run = "bundle exec rake flay"
 
 [tasks."lint:skills"]
 description = "Validate Claude skills"
-sources = ["files/home/.claude/skills/**", "tools/lint_agent_skills.rb"]
+sources = ["files/home/.claude/skills/**", "tools/agent_skill_lint.rb", "tools/agent_skill_lint/**/*.rb", "tools/lint_agent_skills.rb"]
 run = "ruby tools/lint_agent_skills.rb"
 
 [tasks.lint]

--- a/test/skills/agent_skill_equivalence_lint_test.rb
+++ b/test/skills/agent_skill_equivalence_lint_test.rb
@@ -1,0 +1,34 @@
+# standard:disable Dotfiles/BanFileSystemClasses -- black-box linter tests require temporary skill trees
+require_relative "../test_helper"
+require_relative "../support/agent_skill_lint_helper"
+require "tmpdir"
+
+class AgentSkillEquivalenceLintTest < Minitest::Test
+  include AgentSkillLintHelper
+
+  def test_rejects_diverged_files_declared_identical
+    Dir.mktmpdir do |root|
+      body = "`left.md#dont` and `right.md#dont` must stay identical.\n"
+      skill = write_skill(root, "paired", body: body)
+      File.write(File.join(skill, "left.md"), "Unrelated left.\n## Don't\nleft\n")
+      File.write(File.join(skill, "right.md"), "Unrelated right.\n## Don't\nright\n")
+
+      output, status = run_skill_lint(root)
+      refute status.success?
+      assert_includes output, "paired-files-diverge"
+    end
+  end
+
+  def test_rejects_a_prose_count_that_disagrees_with_its_table
+    Dir.mktmpdir do |root|
+      skill = write_skill(root, "counted", body: "The [table](table.md#target) has 3 columns.\n")
+      tables = "| One | Two | Three |\n| --- | --- | --- |\n| A | B | C |\n\n## Target\n| One | Two |\n| --- | --- |\n| A | B |\n"
+      File.write(File.join(skill, "table.md"), tables)
+
+      output, status = run_skill_lint(root)
+      refute status.success?
+      assert_includes output, "prose-count-doesnt-match-referenced-table"
+    end
+  end
+end
+# standard:enable Dotfiles/BanFileSystemClasses

--- a/test/skills/agent_skill_lint_test.rb
+++ b/test/skills/agent_skill_lint_test.rb
@@ -1,0 +1,84 @@
+# standard:disable Dotfiles/BanFileSystemClasses -- black-box linter tests require temporary skill trees
+require_relative "../test_helper"
+require_relative "../support/agent_skill_lint_helper"
+require "json"
+require "tmpdir"
+
+class AgentSkillLintTest < Minitest::Test
+  include AgentSkillLintHelper
+
+  def test_accepts_valid_personal_skills_and_system_references
+    Dir.mktmpdir do |root|
+      write_skill(root, "helper")
+      write_skill(root, "caller", body: "Run a `/helper` session. Run an `/imagegen` session.\n")
+      guarded = "Never use WebFetch. Use WebSearch instead of WebFetch.\nDo not use WebFetch, use WebSearch.\nFor example, WebFetch(query: \"Ruby\").\n```text\nWebFetch(query: \"example\")\nSkill(skill: \"missing\")\n```\n"
+      write_skill(root, "guarded", frontmatter: "name: guarded\ndescription: Guarded\nallowed-tools: WebSearch", body: guarded)
+      write_skill(root, ".system/imagegen", frontmatter: "name: wrong")
+
+      output, status = run_skill_lint(root)
+      assert status.success?, output
+    end
+  end
+
+  def test_rejects_unresolved_internal_skill_invocations
+    Dir.mktmpdir do |root|
+      body = "Run a `/missing` session. Skill(skill: \"also-missing\")\n"
+      write_skill(root, "caller", body: body)
+
+      output, status = run_skill_lint(root)
+      refute status.success?
+      assert_includes output, "/missing does not resolve"
+      assert_includes output, "/also-missing does not resolve"
+    end
+  end
+
+  def test_rejects_instructed_tools_missing_from_allowed_tools
+    Dir.mktmpdir do |root|
+      body = "WebSearch(query: \"Ruby\")\nRun this:\n\n```bash\nruby audit.rb\n```\n"
+      frontmatter = "name: research\ndescription: Research\nallowed-tools: [Read, Bash(git:*)]"
+      write_skill(root, "research", frontmatter: frontmatter, body: body)
+
+      output, status = run_skill_lint(root)
+      refute status.success?
+      assert_includes output, "instructed-tool-not-in-allowed-tools"
+      assert_includes output, "WebSearch"
+      assert_includes output, "Bash"
+    end
+  end
+
+  def test_accepts_allowed_tool_scopes_and_mcp_wildcards
+    Dir.mktmpdir do |root|
+      body = "mcp__docs__search(query: \"Ruby\")\nRun this:\n\n```bash\nbundle exec rake audit\n```\n"
+      frontmatter = "name: docs\ndescription: Docs\nallowed-tools: [mcp__docs__*, Bash(bundle exec:*)]"
+      write_skill(root, "docs", frontmatter: frontmatter, body: body)
+
+      output, status = run_skill_lint(root)
+      assert status.success?, output
+    end
+  end
+
+  def test_rejects_nonsequential_eval_ids
+    Dir.mktmpdir do |root|
+      path = write_skill(root, "review")
+      FileUtils.mkdir_p(File.join(path, "evals"))
+      File.write(File.join(path, "evals", "evals.json"), JSON.generate(evals: [{id: 1}, {id: 3}]))
+
+      output, status = run_skill_lint(root)
+      refute status.success?
+      assert_includes output, "eval-quality-issues"
+    end
+  end
+
+  def test_enforces_documented_frontmatter_conventions
+    Dir.mktmpdir do |root|
+      write_skill(root, "actual", frontmatter: "name: Invalid_Name_That_Is_Much_Longer_Than_Forty_Characters\ndescription:")
+
+      output, status = run_skill_lint(root)
+      refute status.success?
+      assert_includes output, "Skill name must match directory"
+      assert_includes output, "Skill name must use 1–40 lowercase"
+      assert_includes output, "Skill description is required"
+    end
+  end
+end
+# standard:enable Dotfiles/BanFileSystemClasses

--- a/test/support/agent_skill_lint_helper.rb
+++ b/test/support/agent_skill_lint_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# standard:disable Dotfiles/BanFileSystemClasses -- black-box linter helpers require temporary skill trees
+
+require "fileutils"
+require "open3"
+
+module AgentSkillLintHelper
+  SCRIPT = File.expand_path("../../tools/lint_agent_skills.rb", __dir__)
+
+  private
+
+  def write_skill(root, name, frontmatter: nil, body: "Instructions.\n")
+    path = File.join(root, name)
+    FileUtils.mkdir_p(path)
+    frontmatter ||= "name: #{File.basename(name)}\ndescription: Valid skill"
+    File.write(File.join(path, "SKILL.md"), "---\n#{frontmatter}\n---\n#{body}")
+    path
+  end
+
+  def run_skill_lint(root)
+    Open3.capture2e(RbConfig.ruby, SCRIPT, root)
+  end
+end
+# standard:enable Dotfiles/BanFileSystemClasses

--- a/tools/agent_skill_lint.rb
+++ b/tools/agent_skill_lint.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "find"
+require "json"
+require "yaml"
+require_relative "agent_skill_lint/equivalence_checks"
+require_relative "agent_skill_lint/eval_checks"
+require_relative "agent_skill_lint/reference_checks"
+
+# Implements the mechanically checkable findings from Intercom's skill-review rubric:
+# https://github.com/intercom/2x-skills/blob/main/plugins/skill-tools/skills/skill-review/SKILL.md
+class AgentSkillLint
+  include AgentSkillEquivalenceChecks
+  include AgentSkillEvalChecks
+  include AgentSkillReferenceChecks
+
+  SEVERITIES = {
+    "eval-quality-issues" => "minor",
+    "repo-convention-violation" => "minor"
+  }.freeze
+
+  def initialize(root)
+    @root = root
+  end
+
+  def errors
+    lowercase_skill_paths + skill_paths.flat_map { |path| skill_errors(path) }
+  end
+
+  private
+
+  attr_reader :root
+
+  def skill_errors(path)
+    frontmatter = load_frontmatter(path)
+    return [finding("repo-convention-violation", "Missing YAML frontmatter", path)] unless frontmatter
+
+    convention_errors(path, frontmatter) + reference_errors(path, frontmatter) + equivalence_errors(path) + eval_errors(path)
+  rescue Psych::SyntaxError => e
+    [finding("repo-convention-violation", "Invalid YAML frontmatter: #{e.message}", path)]
+  end
+
+  def convention_errors(path, frontmatter)
+    expected = File.basename(File.dirname(path))
+    errors = []
+    name = frontmatter["name"].to_s.strip
+    unless name == expected
+      errors << finding("repo-convention-violation", "Skill name must match directory #{expected.inspect}", path)
+    end
+    unless name.match?(/\A[a-z0-9]+(?:-[a-z0-9]+)*\z/) && name.length.between?(1, 40)
+      errors << finding("repo-convention-violation", "Skill name must use 1–40 lowercase letters, digits, and single hyphens", path)
+    end
+    if frontmatter["description"].to_s.strip.empty?
+      errors << finding("repo-convention-violation", "Skill description is required", path)
+    end
+    errors
+  end
+
+  def lowercase_skill_paths
+    paths_under_skills.select { |path| File.basename(path) == "skill.md" }.map do |path|
+      finding("repo-convention-violation", "Use SKILL.md, not skill.md", path)
+    end
+  end
+
+  def skill_names
+    @skill_names ||= skill_paths.map { |path| File.basename(File.dirname(path)) }
+  end
+
+  def skill_paths
+    @skill_paths ||= paths_under_skills.select { |path| File.basename(path) == "SKILL.md" }.sort
+  end
+
+  def paths_under_skills
+    paths = []
+    Find.find(root) do |path|
+      Find.prune if File.directory?(path) && File.basename(path) == ".system"
+      paths << path if File.file?(path)
+    end
+    paths
+  end
+
+  def load_frontmatter(path)
+    match = File.read(path).match(/\A---\n(.*?)\n---\n/m)
+    YAML.safe_load(match[1]) || {} if match
+  end
+
+  def finding(type, message, path)
+    severity = SEVERITIES.fetch(type, "major")
+    "#{type} (deterministic, #{severity}): #{message}: #{path.delete_prefix("#{root}/")}"
+  end
+end

--- a/tools/agent_skill_lint/equivalence_checks.rb
+++ b/tools/agent_skill_lint/equivalence_checks.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module AgentSkillEquivalenceChecks
+  private
+
+  def equivalence_errors(path)
+    markdown_files(path).flat_map do |file|
+      content = File.read(file)
+      paired_file_errors(file, content) + prose_count_errors(file, content)
+    end
+  end
+
+  def paired_file_errors(file, content)
+    content.lines.filter_map do |line|
+      next unless line.match?(/must (?:be |remain |stay )?(?:identical|the same|match)/i)
+
+      references = line.scan(/(?:`|\]\()([^`\s)]+\.[a-z0-9]+(?:#[a-z0-9-]+)?)/i).flatten
+      next unless references.length == 2
+
+      sections = references.map { |reference| referenced_content(file, reference) }
+      next unless sections.all? && sections.uniq.length > 1
+
+      finding("paired-files-diverge", "Paired files or sections declared identical do not match", file)
+    end
+  end
+
+  def prose_count_errors(file, content)
+    content.lines.filter_map do |line|
+      claim = line.match(/\b(\d+)\s+(columns|patterns)\b/i)
+      link = line.match(/\[[^\]]+\]\(([^)]+)\)/)
+      next unless claim && link
+
+      table = referenced_content(file, link[1])
+      actual = table_size(table, claim[2].downcase) if table
+      next unless actual && actual != claim[1].to_i
+
+      finding("prose-count-doesnt-match-referenced-table", "Claims #{claim[1]} #{claim[2]}, but the table has #{actual}", file)
+    end
+  end
+
+  def referenced_content(source, reference)
+    relative, anchor = reference.split("#", 2)
+    path = File.expand_path(relative, File.dirname(source))
+    return unless File.file?(path)
+
+    content = File.read(path)
+    anchor ? anchored_section(content, anchor) : content
+  end
+
+  def anchored_section(content, anchor)
+    lines = content.lines
+    start = lines.index { |line| heading_slug(line) == anchor }
+    return unless start
+
+    level = heading_level(lines[start])
+    finish = lines.each_index.find { |index| index > start && heading_level(lines[index]).between?(1, level) }
+    lines[start...(finish || lines.length)].join
+  end
+
+  def heading_slug(line)
+    return unless heading_level(line).positive?
+
+    line.sub(/^#+\s+/, "").strip.downcase.gsub(/[^[:alnum:]\s-]/, "").gsub(/\s+/, "-").delete_suffix("-")
+  end
+
+  def heading_level(line)
+    line[/\A#+(?=\s)/]&.length.to_i
+  end
+
+  def table_size(content, kind)
+    lines = content.lines
+    separator = lines.index { |line| line.match?(/^\s*\|?(?:\s*:?-+:?\s*\|)+/) }
+    return unless separator&.positive?
+    return table_cells(lines[separator - 1]) if kind == "columns"
+
+    lines[(separator + 1)..].take_while { |line| line.include?("|") && !line.strip.empty? }.length
+  end
+
+  def table_cells(line)
+    line.strip.delete_prefix("|").delete_suffix("|").split("|").length
+  end
+
+  def markdown_files(path)
+    Dir.glob(File.join(File.dirname(path), "**", "*.md")).sort
+  end
+end

--- a/tools/agent_skill_lint/eval_checks.rb
+++ b/tools/agent_skill_lint/eval_checks.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module AgentSkillEvalChecks
+  private
+
+  def eval_errors(path)
+    eval_path = File.join(File.dirname(path), "evals", "evals.json")
+    return [] unless File.exist?(eval_path)
+
+    data = JSON.parse(File.read(eval_path))
+    evals = data.is_a?(Hash) ? data.fetch("evals", []) : data
+    ids = evals.filter_map { |item| item["id"] if item.is_a?(Hash) }
+    return [] if ids.empty? || ids == (ids.first..ids.first + ids.length - 1).to_a
+
+    [finding("eval-quality-issues", "Behavioral eval IDs must be sequential", eval_path)]
+  end
+end

--- a/tools/agent_skill_lint/reference_checks.rb
+++ b/tools/agent_skill_lint/reference_checks.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module AgentSkillReferenceChecks
+  private
+
+  def reference_errors(path, frontmatter)
+    body = skill_markdown(path)
+    internal_skill_errors(path, body) + allowed_tool_errors(path, body, frontmatter)
+  end
+
+  def internal_skill_errors(path, body)
+    referenced_skill_names(body).filter_map do |name|
+      next if skill_names.include?(name) || system_skill_names.include?(name)
+
+      finding("internal-slash-command-or-skill-reference-doesnt-resolve", "Internal skill /#{name} does not resolve", path)
+    end
+  end
+
+  def referenced_skill_names(body)
+    slash_names = body.scan(/\bRun (?:an? )?`\/([a-z][a-z0-9-]*)`/i).flatten
+    invoked_names = body.scan(/Skill\s*\(\s*skill:\s*["']([a-z][a-z0-9-]*)["']/).flatten
+    (slash_names + invoked_names).uniq
+  end
+
+  def system_skill_names
+    @system_skill_names ||= Dir.glob(File.join(root, ".system", "*", "SKILL.md")).map do |path|
+      File.basename(File.dirname(path))
+    end
+  end
+
+  def allowed_tool_errors(path, body, frontmatter)
+    return [] unless frontmatter.key?("allowed-tools")
+
+    allowed = Array(frontmatter["allowed-tools"]).flat_map do |value|
+      value.to_s.scan(/[A-Za-z_][A-Za-z0-9_*]*(?:\([^)]*\))?/)
+    end
+    instructed_tools(body).reject { |tool| tool_allowed?(tool, allowed) }.map do |tool|
+      finding("instructed-tool-not-in-allowed-tools", "Instructed tool #{tool} is not in allowed-tools", path)
+    end
+  end
+
+  def instructed_tools(body)
+    tools = instruction_clauses(body).flat_map { |clause| tools_in(clause) }
+    tools.concat(standalone_calls(body))
+    tools.concat(runnable_fence_tools(body))
+    tools.uniq
+  end
+
+  def instruction_clauses(body)
+    body.split(/[.;]\s+|,\s+(?=(?:avoid|call|dispatch|do not|don't|execute|invoke|launch|never|not|run|use)\b)/i).filter_map do |clause|
+      next unless clause.match?(/\b(?:call|dispatch|execute|invoke|launch|run|use)\b/i)
+      next if clause.match?(/\A\s*(?:avoid|do not|don't|never|not)\b/i)
+
+      clause.split(/\b(?:instead of|rather than|not)\b/i, 2).first
+    end
+  end
+
+  def tools_in(clause)
+    tools = clause.scan(/\b(Agent|Skill|Task|WebFetch|WebSearch)\b/).flatten
+    tools.concat(clause.scan(/\b(mcp__[A-Za-z0-9_]+)\b/).flatten)
+  end
+
+  def standalone_calls(body)
+    body.lines.filter_map do |line|
+      line[/\A\s*(?:[-*]\s*)?((?:Agent|Skill|Task|WebFetch|WebSearch|mcp__[A-Za-z0-9_]+))\s*\(/, 1]
+    end
+  end
+
+  def runnable_fence_tools(body)
+    pattern = /^(?![^\n]*(?:avoid|do not|don't|never))[^\n]*\b(?:execute|invoke|run|use)\b[^\n]*\n(?:\s*\n)?```(bash|fish|python|ruby|sh)\b\n(.*?)^```/im
+    body.scan(pattern).filter_map do |language, code|
+      command = if %w[bash fish sh].include?(language.downcase)
+        code.lines.find { |line| line.match?(/^\s*[^#\s]/) }&.strip
+      else
+        language.downcase
+      end
+      "Bash(#{command})" if command
+    end
+  end
+
+  def tool_allowed?(tool, allowed)
+    name, command = tool.match(/\A([^()]+)(?:\(([^)]+)\))?\z/).captures
+    allowed.any? do |entry|
+      scope = entry[/\A#{Regexp.escape(name)}\((.*):\*\)\z/, 1]
+      entry == name || entry == "#{name}(*)" || (scope && command&.start_with?(scope)) ||
+        (entry.end_with?("*") && !entry.include?("(") && name.start_with?(entry.delete_suffix("*")))
+    end
+  end
+
+  def skill_markdown(path)
+    Dir.glob(File.join(File.dirname(path), "**", "*.md")).sort.map do |file|
+      File.read(file).sub(/\A---\n.*?\n---\n/m, "").gsub(/^```(?:md|markdown|text)\b.*?^```/mi, "")
+    end.join("\n")
+  end
+end

--- a/tools/lint_agent_skills.rb
+++ b/tools/lint_agent_skills.rb
@@ -1,75 +1,8 @@
 # frozen_string_literal: true
 
-require "find"
-require "yaml"
+require_relative "agent_skill_lint"
 
-class AgentSkillLint
-  SKILLS_ROOT = File.expand_path("../files/home/.claude/skills", __dir__)
-
-  def run
-    errors = lowercase_skill_paths + invalid_skill_paths
-    return if errors.empty?
-
-    warn errors.join("\n")
-    exit 1
-  end
-
-  private
-
-  def lowercase_skill_paths
-    paths_under_skills.select { |path| File.basename(path) == "skill.md" }.map do |path|
-      "Use SKILL.md, not skill.md: #{relative_path(path)}"
-    end
-  end
-
-  def invalid_skill_paths
-    skill_paths.filter_map do |path|
-      validate_skill(path)
-    end
-  end
-
-  def skill_paths
-    paths_under_skills.select { |path| File.basename(path) == "SKILL.md" }.sort
-  end
-
-  def validate_skill(path)
-    frontmatter = load_frontmatter(path)
-    return "Missing YAML frontmatter: #{relative_path(path)}" unless frontmatter
-
-    name_error(path, frontmatter) || description_error(path, frontmatter)
-  rescue Psych::SyntaxError => e
-    "Invalid YAML frontmatter in #{relative_path(path)}: #{e.message}"
-  end
-
-  def name_error(path, frontmatter)
-    skill_dir = File.basename(File.dirname(path))
-    name = frontmatter["name"].to_s.strip
-    return if name == skill_dir
-
-    "Skill name must match directory #{skill_dir.inspect}: #{relative_path(path)}"
-  end
-
-  def description_error(path, frontmatter)
-    return unless frontmatter["description"].to_s.strip.empty?
-
-    "Skill description is required: #{relative_path(path)}"
-  end
-
-  def load_frontmatter(path)
-    content = File.read(path)
-    match = content.match(/\A---\n(.*?)\n---\n/m)
-    return unless match
-
-    YAML.safe_load(match[1]) || {}
-  end
-
-  def paths_under_skills
-    Find.find(SKILLS_ROOT).select { |path| File.file?(path) }
-  end
-
-  def relative_path(path)
-    path.delete_prefix("#{File.expand_path("..", __dir__)}/")
-  end
-end
-
-AgentSkillLint.new.run
+skills_root = ARGV.first || File.expand_path("../files/home/.claude/skills", __dir__)
+errors = AgentSkillLint.new(skills_root).errors
+warn errors.join("\n") unless errors.empty?
+exit 1 unless errors.empty?


### PR DESCRIPTION
## Summary

- replace the basic Claude skill frontmatter lint with statically enforceable deterministic checks from Intercom's `skill-review` rubric
- reject broken internal skill references, undeclared instructed tools, diverged paired sections, prose/table count mismatches, and non-sequential eval IDs
- preserve the repository's documented skill naming/frontmatter checks while excluding generated `.system` skills
- include the linter implementation files in the `lint:skills` mise task sources

## Validation

- `mise run --force lint:skills`
- `bundle exec rake test` (355 runs, 902 assertions)
- `mise run lint:standard`
- `mise run lint:complexity`
- `mise run lint:dead-code`
- `mise run lint:flog`
- `mise run lint:flay`
- `mise run lint:secrets`

Closes #526
