### PR TITLE
Sync Anthropic webapp-testing license

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ I make changes to this repository exclusively through GitHub pull requests. Push
 ## CI
 
 - CI usually takes about 10 minutes to finish running.
-- Do not use `[ci skip]`, `[skip ci]`, or similar commit-message skip markers in this repository. They leave required PR checks without successful statuses, so the PR gets stuck instead of merging.
+- Never use `[ci skip]`, `[skip ci]`, or similar commit-message skip markers in this repository, including for docs-only changes. GitHub skips required workflows entirely, leaving their checks without successful statuses and the PR stuck.
 - Docs-only changes use the repository's explicit skip mechanisms instead:
   - The integration workflow detects changes limited to `docs/*`, `README.md`, or `AGENTS.md` and skips the integration test steps while still reporting successful required checks.
   - Local `hk`/mise hooks use task `sources` to skip unchanged checks before commit. CI lint and unit-test workflows still run on PRs.

--- a/files/home/.claude/skills/webapp-testing/LICENSE.txt
+++ b/files/home/.claude/skills/webapp-testing/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- sync the `webapp-testing` skill with Anthropic upstream commit `0a64e398ec6bb34a494f0c347e8ccae53a862f8e`
- update the Apache license copyright line
- document why CI skip markers must not be used when required PR checks need successful statuses

All other files in the skill already match upstream.

## Testing

- compared the complete local skill tree against the pinned upstream tree
- repository pre-commit checks