### PR TITLE
Use environment variable for Exa API key

### DIFF
--- a/files/home/.pi/agent/web-providers.json
+++ b/files/home/.pi/agent/web-providers.json
@@ -8,7 +8,7 @@
   "providers": {
     "exa": {
       "credentials": {
-        "api": "!op --account thespeedshop read 'op://Employee/Pi Web Providers/EXA_API_KEY'"
+        "api": "EXA_API_KEY"
       }
     },
     "perplexity": {


### PR DESCRIPTION
## Summary

- read the Exa API key from `EXA_API_KEY`
- stop invoking 1Password whenever the Exa provider needs credentials

## Why

The repeated 1Password prompt for the Exa API key was disruptive.

## Verification

- `jq empty files/home/.pi/agent/web-providers.json`
- gitleaks scan of the changed file