### PR TITLE
Restore pre-migration OmniWM settings

### DIFF
--- a/files/home/.config/omniwm/settings.toml
+++ b/files/home/.config/omniwm/settings.toml
@@ -1,6 +1,57 @@
 [general]
 updateChecksEnabled = false
 
+[appearance]
+mode = "automatic"
+
+[borders]
+enabled = true
+width = 1.0
+
+[gaps]
+size = 4.0
+
+[gaps.outer]
+bottom = 0.0
+left = 0.0
+right = 0.0
+top = 0.0
+
+[hiddenBar]
+enabled = true
+hiddenBundleIDs = []
+rehideIntervalSeconds = 5.0
+
+[mouseWarp]
+constrainToArrangement = false
+enabled = true
+margin = 1
+
+[statusBar]
+showAppNames = false
+showWorkspaceName = false
+useWorkspaceId = false
+
+[workspaceBar]
+backgroundOpacity = 0.1
+deduplicateAppIcons = false
+enabled = true
+excludedBundleIDs = []
+height = 24.0
+hideEmptyWorkspaces = false
+notchActiveZoneWidth = 180.0
+notchMode = "moveBelowMenuBar"
+position = "overlappingMenuBar"
+reserveLayoutSpace = false
+revealHoldMilliseconds = 200.0
+revealModifier = "off"
+showFloatingWindows = false
+showLabels = true
+systemStatsButton = false
+windowLevel = "popup"
+xOffset = 0.0
+yOffset = 0.0
+
 [[hotkeys]]
 binding = "Option+Tab"
 id = "workspaceBackAndForth"


### PR DESCRIPTION
## Summary

- restore the OmniWM appearance settings that were accidentally dropped in #555
- restore the 1-point borders and 4-point gaps from the recovered pre-migration config
- restore the enabled workspace bar overlapping the macOS menu bar
- preserve the recovered hidden-bar, status-bar, and mouse-warp behavior

## Verification

- `bundle exec rake test`
- relevant lint and pre-commit checks
- targeted gitleaks scan of the changed file
- parsed the resulting file with the Ruby TOML parser
- exact comparison against recovered Git blob `e60dbc8049a016d82f4d953d6c94cc2df5ad8af2`