### PR TITLE
Restore unassigned OmniWM hotkeys

### DIFF
--- a/files/home/.config/omniwm/settings.toml
+++ b/files/home/.config/omniwm/settings.toml
@@ -127,3 +127,15 @@ id = "cycleSizeBackward"
 [[hotkeys]]
 binding = "Hyper+L"
 id = "toggleWorkspaceLayout"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleFullscreen"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "setContainerPrimarySpan.decrease10Percent"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "setContainerPrimarySpan.increase10Percent"

--- a/test/omniwm_settings_test.rb
+++ b/test/omniwm_settings_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+require "toml-rb"
+
+class OmniWMSettingsTest < Minitest::Test
+  def test_preserves_unassigned_hotkey_overrides
+    assert_equal "Unassigned", hotkeys.fetch("toggleFullscreen")
+    assert_equal "Unassigned", hotkeys.fetch("setContainerPrimarySpan.decrease10Percent")
+    assert_equal "Unassigned", hotkeys.fetch("setContainerPrimarySpan.increase10Percent")
+  end
+
+  private
+
+  def hotkeys
+    @hotkeys ||= TomlRB.load_file(settings_path).fetch("hotkeys").to_h do |hotkey|
+      [hotkey.fetch("id"), hotkey.fetch("binding")]
+    end
+  end
+
+  def settings_path
+    File.expand_path("../files/home/.config/omniwm/settings.toml", __dir__)
+  end
+end


### PR DESCRIPTION
## Summary

- restore the pre-migration `Option+Return` override by keeping `toggleFullscreen` unassigned
- preserve the two unassigned container-span actions displaced by the custom `Option+Minus` and `Option+Equal` bindings
- add a regression test for all recovered unassigned overrides

## Root cause

The sparse config introduced in #555 copied assigned hotkeys but dropped explicit `Unassigned` entries. OmniWM fills missing entries from defaults, which re-enabled `Option+Return` and the default container-span shortcuts.

## Verification

- recovered the original values from pre-migration Git blob `e60dbc8049a016d82f4d953d6c94cc2df5ad8af2`
- compared them with OmniWM v0.6.2's `ActionCatalog` defaults
- `bundle exec rake test` (371 runs, 885 assertions)
- `bundle exec standardrb test/omniwm_settings_test.rb`
- applied the corrected config locally and verified all three actions are unassigned
