### PR TITLE
Configure OmniWM widths per monitor

### DIFF
--- a/files/home/.config/omniwm/settings.toml
+++ b/files/home/.config/omniwm/settings.toml
@@ -17,6 +17,21 @@ left = 0.0
 right = 0.0
 top = 0.0
 
+[niri]
+visibleContainerCount = 2
+
+[[monitorNiriOverrides]]
+id = "3AE883DE-B85C-48F3-838C-45CE7841BB03"
+monitorName = "DELL G3223Q"
+monitorDisplayUUID = "E165D445-477D-4D2D-95E0-500E9940FE59"
+visibleContainerCount = 3
+
+[[monitorNiriOverrides]]
+id = "288ABB9D-D8C5-42A0-9147-1E19174FAA4F"
+monitorName = "Built-in Retina Display"
+monitorDisplayUUID = "37D8832A-2D66-02CA-B9F7-8F30A301B230"
+visibleContainerCount = 2
+
 [hiddenBar]
 enabled = true
 hiddenBundleIDs = []

--- a/test/omniwm_settings_test.rb
+++ b/test/omniwm_settings_test.rb
@@ -8,11 +8,27 @@ class OmniWMSettingsTest < Minitest::Test
     assert_equal "Unassigned", hotkeys.fetch("setContainerPrimarySpan.increase10Percent")
   end
 
+  def test_uses_monitor_specific_automatic_column_widths
+    refute settings.fetch("niri").key?("defaultContainerPrimarySpan")
+    assert_equal 3, visible_container_counts.fetch("DELL G3223Q")
+    assert_equal 2, visible_container_counts.fetch("Built-in Retina Display")
+  end
+
   private
 
+  def settings
+    @settings ||= TomlRB.load_file(settings_path)
+  end
+
   def hotkeys
-    @hotkeys ||= TomlRB.load_file(settings_path).fetch("hotkeys").to_h do |hotkey|
+    @hotkeys ||= settings.fetch("hotkeys").to_h do |hotkey|
       [hotkey.fetch("id"), hotkey.fetch("binding")]
+    end
+  end
+
+  def visible_container_counts
+    settings.fetch("monitorNiriOverrides").to_h do |monitor|
+      [monitor.fetch("monitorName"), monitor.fetch("visibleContainerCount")]
     end
   end
 


### PR DESCRIPTION
## Summary
- use automatic Niri column sizing
- show three columns on the DELL G3223Q for 33% widths
- show two columns on the built-in Retina display for 50% widths
- test the monitor-specific settings

## Testing
- `bundle exec rake test`
- `bundle exec standardrb test/omniwm_settings_test.rb`