### PR TITLE
Make mise bootstrap more resilient

### DIFF
--- a/files/home/.config/mise/mise.lock
+++ b/files/home/.config/mise/mise.lock
@@ -180,7 +180,7 @@ version = "2.10"
 backend = "github:aldanial/cloc"
 
 [tools."github:aldanial/cloc".options]
-asset_pattern = "cloc-2.10.pl"
+asset_pattern = "cloc-{version}.pl"
 
 [tools."github:aldanial/cloc"."platforms.linux-x64"]
 checksum = "sha256:bf59272455172108072a0a106379f7509fd4349bdcfd85203bac038ccd286d83"

--- a/files/home/.npmrc
+++ b/files/home/.npmrc
@@ -1,4 +1,4 @@
 fetch-timeout=5000
-fetch-retries=0
+fetch-retries=1
 ignore-scripts=true
 min-release-age=3


### PR DESCRIPTION
## Summary

- retry transient npm registry fetch failures once while retaining the five-second timeout
- align cloc's locked asset pattern with mise's resolved tool identity

## Why

Aube had no retries, so transient response-body failures required rerunning `dotf run`. Separately, mise rejected the existing cloc lock entry under `--locked` because its stored asset pattern did not match the resolved config pattern.

## Validation

- isolated `mise install github:aldanial/cloc@2.10 --dry-run --locked`
- targeted `mise lock github:aldanial/cloc` leaves the fixture lock unchanged
- aube reads `fetch-retries=1` from the managed `.npmrc`
- `bundle exec rake test` (372 runs, 906 assertions)