### PR TITLE
Enable Touch ID for sudo

### DIFF
--- a/files/templates/sudo_local
+++ b/files/templates/sudo_local
@@ -1,0 +1,3 @@
+# sudo_local: local config file which survives system update and is included for sudo
+# Enable Touch ID for sudo.
+auth       sufficient     pam_tid.so

--- a/lib/dotfiles/steps/mac/enable_sudo_touch_id_step.rb
+++ b/lib/dotfiles/steps/mac/enable_sudo_touch_id_step.rb
@@ -1,0 +1,34 @@
+class Dotfiles::Step::EnableSudoTouchIDStep < Dotfiles::Step
+  DESCRIPTION = "Enables Touch ID authentication for sudo.".freeze
+
+  prepend Dotfiles::Step::Sudoable
+
+  macos_only
+
+  def run
+    return add_error("Refusing to replace existing #{target_path}") if @system.file_exist?(target_path)
+
+    _, status = execute(command("install", "-o", "root", "-g", "wheel", "-m", "0444", source_path, target_path), sudo: true)
+    add_error("Failed to enable Touch ID for sudo") unless status == 0
+  end
+
+  def complete?
+    super
+    add_error("Touch ID is not enabled for sudo") unless enabled?
+    @errors.empty?
+  end
+
+  private
+
+  def enabled?
+    @system.file_exist?(target_path) && @system.readlines(target_path).any? { |line| line.split == %w[auth sufficient pam_tid.so] }
+  end
+
+  def source_path
+    File.join(@dotfiles_dir, "files", "templates", "sudo_local")
+  end
+
+  def target_path
+    "/etc/pam.d/sudo_local"
+  end
+end

--- a/test/dotfiles/steps/enable_sudo_touch_id_step_test.rb
+++ b/test/dotfiles/steps/enable_sudo_touch_id_step_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class EnableSudoTouchIDStepTest < StepTestCase
+  step_class Dotfiles::Step::EnableSudoTouchIDStep
+
+  def setup
+    super
+    @fake_system.stub_macos
+  end
+
+  def test_incomplete_when_sudo_local_is_missing
+    assert_incomplete
+  end
+
+  def test_complete_when_touch_id_is_enabled
+    @fake_system.stub_file_content(target_path, "auth       sufficient     pam_tid.so\n")
+
+    assert_complete
+  end
+
+  def test_run_installs_sudo_local
+    step.run
+
+    assert_executed(
+      ["sudo", "install", "-o", "root", "-g", "wheel", "-m", "0444", source_path, target_path],
+      quiet: false
+    )
+  end
+
+  def test_run_reports_install_failure
+    command = ["sudo", "install", "-o", "root", "-g", "wheel", "-m", "0444", source_path, target_path]
+    @fake_system.stub_command(command, "permission denied", 1)
+
+    step.run
+
+    assert_includes step.errors, "Failed to enable Touch ID for sudo"
+  end
+
+  def test_run_refuses_to_replace_existing_sudo_local
+    @fake_system.stub_file_content(target_path, "auth required pam_opendirectory.so\n")
+
+    step.run
+
+    assert_includes step.errors, "Refusing to replace existing #{target_path}"
+    refute_executed ["sudo", "install", "-o", "root", "-g", "wheel", "-m", "0444", source_path, target_path]
+  end
+
+  def test_complete_in_ci_when_sudo_local_is_missing
+    with_ci { assert_complete }
+  end
+
+  def test_does_not_run_off_macos
+    @fake_system.stub_macos(false)
+
+    refute_should_run
+  end
+
+  private
+
+  def source_path
+    File.join(@dotfiles_dir, "files", "templates", "sudo_local")
+  end
+
+  def target_path
+    "/etc/pam.d/sudo_local"
+  end
+end


### PR DESCRIPTION
## Summary

- install Apple’s persistent `/etc/pam.d/sudo_local` configuration on macOS
- enable `pam_tid.so` as a sufficient sudo authentication method
- preserve password fallback through the standard sudo PAM stack
- refuse to overwrite any existing `sudo_local` configuration

## Security

This uses Apple’s supported Sonoma-and-later `sudo_local` integration. The installed file is owned by root, grouped to wheel, and mode `0444`. Existing local PAM policy fails closed for manual review instead of being replaced.

## Validation

- `mise run lint`
- `bundle exec rake test` (379 runs, 916 assertions)
- independent security-focused review found no blockers
