### PR TITLE
Fix Spotlight battery convergence and manage local configs

### DIFF
--- a/files/home/.config/gh/config.yml
+++ b/files/home/.config/gh/config.yml
@@ -1,0 +1,16 @@
+# What protocol to use when performing git operations. Supported values: ssh, https
+git_protocol: ssh
+# What editor gh should run when creating issues, pull requests, etc. If blank, will refer to environment.
+editor:
+# When to interactively prompt. This is a global config that cannot be overridden by hostname. Supported values: enabled, disabled
+prompt: enabled
+# A pager program to send command output to, e.g. "less". Set the value to "cat" to disable the pager.
+pager:
+# Aliases allow you to create nicknames for gh commands
+aliases:
+    co: pr checkout
+# The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
+http_unix_socket:
+# What web browser gh should use when opening URLs. If blank, will refer to environment.
+browser:
+version: "1"

--- a/files/home/.gemrc
+++ b/files/home/.gemrc
@@ -1,0 +1,2 @@
+:verbose: :really
+gem: --no-document

--- a/files/home/.pi/agent/extensions/fireworks_intent.ts
+++ b/files/home/.pi/agent/extensions/fireworks_intent.ts
@@ -1,0 +1,63 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const FIREWORKS_PROVIDER = "fireworks";
+
+type FireworksAlias = {
+	targetModel: string;
+	serviceTier?: "priority";
+};
+
+type ProviderPayload = {
+	model?: unknown;
+	service_tier?: unknown;
+	[key: string]: unknown;
+};
+
+const MODEL_ALIASES: Record<string, FireworksAlias> = {
+	"kimi-k2p6": {
+		targetModel: "accounts/fireworks/models/kimi-k2p6",
+	},
+	"kimi-k2p6-priority": {
+		targetModel: "accounts/fireworks/models/kimi-k2p6",
+		serviceTier: "priority",
+	},
+	"kimi-k2p6-fast": {
+		targetModel: "accounts/fireworks/routers/kimi-k2p6-fast",
+	},
+	"glm-5p2": {
+		targetModel: "accounts/fireworks/models/glm-5p2",
+	},
+	"glm-5p2-priority": {
+		targetModel: "accounts/fireworks/models/glm-5p2",
+		serviceTier: "priority",
+	},
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function rewrittenPayload(payload: ProviderPayload, alias: FireworksAlias) {
+	const { service_tier: _serviceTier, ...rest } = payload;
+
+	return {
+		...rest,
+		model: alias.targetModel,
+		...(alias.serviceTier ? { service_tier: alias.serviceTier } : {}),
+	};
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.on("before_provider_request", (event, ctx) => {
+		if (ctx.model?.provider !== FIREWORKS_PROVIDER) return;
+		if (!isRecord(event.payload)) return;
+
+		const payload = event.payload as ProviderPayload;
+		if (typeof payload.model !== "string") return;
+
+		const alias = MODEL_ALIASES[payload.model];
+		if (!alias) return;
+
+		return rewrittenPayload(payload, alias);
+	});
+}

--- a/lib/dotfiles/steps/mac/configure_spotlight_battery_step.rb
+++ b/lib/dotfiles/steps/mac/configure_spotlight_battery_step.rb
@@ -7,13 +7,13 @@ class Dotfiles::Step::ConfigureSpotlightBatteryStep < Dotfiles::Step
   macos_only
 
   def should_run?
-    battery_mode_enabled? && !battery_toggle_installed?
+    battery_mode_enabled? && !battery_toggle_current?
   end
 
   def run
     return unless fish_path
-    install_script(script_path, script_content) unless @system.file_exist?(script_path)
-    install_spotlight_launchdaemon unless @system.file_exist?(launchdaemon_path)
+    install_script(script_path, script_content) unless script_current?
+    install_spotlight_launchdaemon unless launchdaemon_current?
     load_launchdaemon(launchdaemon_path)
   end
 
@@ -22,15 +22,27 @@ class Dotfiles::Step::ConfigureSpotlightBatteryStep < Dotfiles::Step
     return true unless battery_mode_enabled?
 
     add_error("Fish not found for Spotlight battery toggle") unless fish_path
-    add_error("Spotlight battery script not installed at #{script_path}") unless @system.file_exist?(script_path)
-    add_error("LaunchDaemon not installed at #{launchdaemon_path}") unless @system.file_exist?(launchdaemon_path)
+    add_error("Spotlight battery script is missing or stale at #{script_path}") unless script_current?
+    add_error("LaunchDaemon is missing or stale at #{launchdaemon_path}") unless launchdaemon_current?
     @errors.empty?
   end
 
   private
 
-  def battery_toggle_installed?
-    @system.file_exist?(script_path) && @system.file_exist?(launchdaemon_path)
+  def battery_toggle_current?
+    script_current? && launchdaemon_current?
+  end
+
+  def script_current?
+    current_file?(script_path, script_content)
+  end
+
+  def launchdaemon_current?
+    current_file?(launchdaemon_path, plist_content)
+  end
+
+  def current_file?(path, content)
+    @system.file_exist?(path) && @system.read_file(path) == content
   end
 
   def script_content
@@ -43,10 +55,11 @@ class Dotfiles::Step::ConfigureSpotlightBatteryStep < Dotfiles::Step
       end
 
       set -l power_line (/usr/bin/pmset -g batt | head -n 1)
+      set -l desired
       if string match -q "*Battery Power*" -- $power_line
-        set -l desired off
+        set desired off
       else if string match -q "*AC Power*" -- $power_line
-        set -l desired on
+        set desired on
       else
         exit 0
       end

--- a/test/dotfiles/steps/configure_spotlight_battery_step_test.rb
+++ b/test/dotfiles/steps/configure_spotlight_battery_step_test.rb
@@ -33,11 +33,45 @@ class ConfigureSpotlightBatteryStepTest < StepTestCase
     assert_includes plist, "<string>/System/Volumes/Data</string>"
   end
 
+  def test_generated_script_keeps_desired_state_in_scope
+    write_spotlight_config
+    stub_fish_path
+
+    script = step.send(:script_content)
+
+    assert_includes script, "set -l desired\n"
+    assert_includes script, "set desired off"
+    assert_includes script, "set desired on"
+    refute_includes script, "set -l desired off"
+    refute_includes script, "set -l desired on"
+  end
+
+  def test_should_run_when_generated_files_are_stale
+    write_spotlight_config
+    stub_fish_path
+    @fake_system.write_file(script_path, "stale")
+    @fake_system.write_file(launchdaemon_path, "stale")
+
+    assert_should_run
+  end
+
+  def test_run_replaces_stale_generated_files
+    write_spotlight_config
+    stub_fish_path
+    @fake_system.write_file(script_path, "stale")
+    @fake_system.write_file(launchdaemon_path, "stale")
+
+    step.run
+
+    assert_equal step.send(:script_content), @fake_system.read_file(script_path)
+    assert_equal step.send(:plist_content), @fake_system.read_file(launchdaemon_source_path)
+    assert_executed("sudo install -m 644 #{launchdaemon_source_path} #{launchdaemon_path}", quiet: false)
+  end
+
   def test_complete_when_battery_mode_installed
     write_spotlight_config
     stub_fish_path
-    @fake_system.write_file(script_path, "")
-    @fake_system.write_file(launchdaemon_path, "")
+    write_current_generated_files
 
     assert_complete
   end
@@ -72,6 +106,11 @@ class ConfigureSpotlightBatteryStepTest < StepTestCase
 
   def stub_macos
     @fake_system.define_singleton_method(:macos?) { true }
+  end
+
+  def write_current_generated_files
+    @fake_system.write_file(script_path, step.send(:script_content))
+    @fake_system.write_file(launchdaemon_path, step.send(:plist_content))
   end
 
   def fish_path


### PR DESCRIPTION
## Summary

- fix Fish scoping in the Spotlight battery script
- replace stale generated Spotlight scripts and LaunchDaemon plists by content, not presence
- manage the selected GH, RubyGems, and Fireworks Pi configuration

## Validation

- `bundle exec rake test` (384 runs, 932 assertions)
- `mise run lint`
- independent reviewer found no blockers
- live Spotlight indexing disabled on `/`; `/System/Volumes/Data` is transitioning to disabled

One-time machine cleanup was applied directly and is intentionally not memorialized as a migration.