### PR TITLE
Add nonblocking dotfiles update notice

### DIFF
--- a/bin/dotf
+++ b/bin/dotf
@@ -173,6 +173,15 @@ release_dotf_lock() {
     rm -rf "$DOTF_LOCK_DIR" 2>/dev/null || true
 }
 
+record_successful_run() {
+    local state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles"
+
+    mkdir -p "$state_dir"
+    git -C "$DOTFILES_DIR" rev-parse HEAD > "$state_dir/last-run-sha.tmp"
+    mv "$state_dir/last-run-sha.tmp" "$state_dir/last-run-sha"
+    rm -f "$state_dir/needs-run"
+}
+
 cmd_run() {
     acquire_dotf_lock
     init_logging
@@ -191,6 +200,7 @@ cmd_run() {
         "${migration_command[@]}" >> "$LOG_FILE"
     fi
     ruby -r ./lib/dotfiles.rb -e "Dotfiles::Runner.new('$LOG_FILE').run"
+    record_successful_run
 
     debug "Run complete"
 }

--- a/bin/dotf
+++ b/bin/dotf
@@ -175,9 +175,11 @@ release_dotf_lock() {
 
 record_successful_run() {
     local state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles"
+    local applied_sha
+    applied_sha="$(git -C "$DOTFILES_DIR" rev-parse HEAD 2>/dev/null)" || return 0
 
     mkdir -p "$state_dir"
-    git -C "$DOTFILES_DIR" rev-parse HEAD > "$state_dir/last-run-sha.tmp"
+    printf '%s\n' "$applied_sha" > "$state_dir/last-run-sha.tmp"
     mv "$state_dir/last-run-sha.tmp" "$state_dir/last-run-sha"
     rm -f "$state_dir/needs-run"
 }

--- a/files/home/.config/fish/config.fish
+++ b/files/home/.config/fish/config.fish
@@ -9,6 +9,22 @@ ulimit -S -n 4000
 set -g fish_greeting
 
 function fish_greeting
+    set -l state_home "$HOME/.local/state"
+    set -q XDG_STATE_HOME; and set state_home "$XDG_STATE_HOME"
+
+    if test -e "$state_home/dotfiles/needs-run"
+        set -l message 'Dotfiles changed on origin/main.'
+        set -l update_command 'cd ~/.dotfiles && git switch main && git pull --ff-only && dotf run'
+        if command -q gum
+            printf '%s\n%s\n' "$message" "$update_command" | gum style --bold --foreground 214
+        else
+            printf '%s\n%s\n' "$message" "$update_command"
+        end
+    end
+
+    command fish --no-config --command __dotf_refresh_update_notice >/dev/null 2>&1 &
+    disown $last_pid 2>/dev/null
+    return 0
 end
 
 set -x LANG en_US.UTF-8

--- a/files/home/.config/fish/functions/__dotf_refresh_update_notice.fish
+++ b/files/home/.config/fish/functions/__dotf_refresh_update_notice.fish
@@ -1,0 +1,36 @@
+function __dotf_refresh_update_notice
+    set -l repo "$HOME/.dotfiles"
+    set -q DOTFILES_DIR; and set repo "$DOTFILES_DIR"
+
+    set -l state_home "$HOME/.local/state"
+    set -q XDG_STATE_HOME; and set state_home "$XDG_STATE_HOME"
+
+    set -l state_dir "$state_home/dotfiles"
+    set -l checked_at "$state_dir/checked-at"
+    set -l now (date +%s)
+
+    if test -f "$checked_at"; and read -l last_check <"$checked_at"; and string match --quiet --regex '^\d+$' "$last_check"; and test (math "$now - $last_check") -lt 300
+        return
+    end
+
+    command mkdir -p "$state_dir"
+    command mkdir "$state_dir/check.lock" 2>/dev/null; or return
+
+    printf '%s\n' "$now" >"$checked_at.tmp.$fish_pid"
+    command mv "$checked_at.tmp.$fish_pid" "$checked_at"
+
+    set -l fetch_ref refs/dotfiles/update-notice/main
+    if env GIT_TERMINAL_PROMPT=0 \
+            GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=3 -o ServerAliveInterval=3 -o ServerAliveCountMax=1' \
+            git -C "$repo" fetch --quiet --no-tags origin "+refs/heads/main:$fetch_ref"; and test -f "$state_dir/last-run-sha"; and read -l applied_sha <"$state_dir/last-run-sha"
+        set -l remote_sha (command git -C "$repo" rev-parse "$fetch_ref" 2>/dev/null)
+        if test "$remote_sha" = "$applied_sha"; or command git -C "$repo" merge-base --is-ancestor "$remote_sha" "$applied_sha" 2>/dev/null
+            command rm -f "$state_dir/needs-run"
+        else
+            printf 'dotf run\n' >"$state_dir/needs-run.tmp.$fish_pid"
+            command mv "$state_dir/needs-run.tmp.$fish_pid" "$state_dir/needs-run"
+        end
+    end
+
+    command rmdir "$state_dir/check.lock"
+end

--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -25,7 +25,6 @@
   "enabledModels": [
     "openai-codex/gpt-5.6-sol:medium",
     "openai-codex/gpt-5.6-terra:xhigh",
-    "x-ai/grok-4.5",
     "fireworks/glm-5p2-priority"
   ],
   "subagents": {

--- a/test/dotfiles/dotf_cli_test.rb
+++ b/test/dotfiles/dotf_cli_test.rb
@@ -125,6 +125,7 @@ class DotfCliTest < Minitest::Test
       assert status.success?
       refute_includes stdout, "Running migration"
       assert_run_commands(log_path)
+      assert_equal "test-sha\n", File.read(File.join(tmpdir, "state", "dotfiles", "last-run-sha"))
     end
   end
 
@@ -189,7 +190,12 @@ class DotfCliTest < Minitest::Test
     escaped_log = Shellwords.escape(log_path)
     <<~BASH
       source #{escaped_script}
+      export HOME=#{Shellwords.escape(File.join(File.dirname(escaped_log), "home"))}
+      export XDG_STATE_HOME=#{Shellwords.escape(File.join(File.dirname(escaped_log), "state"))}
       export DOTF_LOCK_DIR=#{Shellwords.escape(File.join(File.dirname(escaped_log), "dotf.lock"))}
+      git() {
+        printf 'test-sha\n'
+      }
       mise() {
         printf 'mise %s\\n' "$*" >> #{escaped_log}
       }

--- a/test/dotfiles/dotf_cli_test.rb
+++ b/test/dotfiles/dotf_cli_test.rb
@@ -129,6 +129,16 @@ class DotfCliTest < Minitest::Test
     end
   end
 
+  def test_record_successful_run_does_nothing_outside_a_git_checkout
+    with_dotf_script do |tmpdir, script_path, _logs_dir|
+      state_home = File.join(tmpdir, "state")
+      command = "source #{Shellwords.escape(script_path)}; record_successful_run"
+
+      assert system({"XDG_STATE_HOME" => state_home}, "bash", "-c", command)
+      refute Dir.exist?(File.join(state_home, "dotfiles"))
+    end
+  end
+
   private
 
   def mise_bootstrap_result(tmpdir, script_path, admin:, debian: false, exit_status: 0, debug: false)

--- a/test/fish/dotf_update_notice_test.rb
+++ b/test/fish/dotf_update_notice_test.rb
@@ -6,6 +6,10 @@ require "tmpdir"
 class DotfUpdateNoticeTest < Minitest::Test
   FUNCTION_PATH = File.expand_path("../../files/home/.config/fish/functions/__dotf_refresh_update_notice.fish", __dir__)
 
+  def setup
+    skip "Fish is not installed" unless system("fish", "--version", out: File::NULL)
+  end
+
   def test_marks_dotfiles_when_origin_main_advanced_since_last_run
     with_repositories do |tmpdir, source, checkout, initial_sha|
       commit_and_push(source, "new change")

--- a/test/fish/dotf_update_notice_test.rb
+++ b/test/fish/dotf_update_notice_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+require "open3"
+require "tmpdir"
+
+# standard:disable Dotfiles/BanFileSystemClasses
+class DotfUpdateNoticeTest < Minitest::Test
+  FUNCTION_PATH = File.expand_path("../../files/home/.config/fish/functions/__dotf_refresh_update_notice.fish", __dir__)
+
+  def test_marks_dotfiles_when_origin_main_advanced_since_last_run
+    with_repositories do |tmpdir, source, checkout, initial_sha|
+      commit_and_push(source, "new change")
+      run_check(checkout, File.join(tmpdir, "state"), initial_sha)
+
+      assert File.exist?(File.join(tmpdir, "state", "dotfiles", "needs-run"))
+    end
+  end
+
+  def test_leaves_no_mark_when_last_run_includes_origin_main
+    with_repositories do |tmpdir, source, checkout, _initial_sha|
+      current_sha = commit_and_push(source, "new change")
+      run_check(checkout, File.join(tmpdir, "state"), current_sha)
+
+      refute File.exist?(File.join(tmpdir, "state", "dotfiles", "needs-run"))
+    end
+  end
+
+  def test_preserves_existing_mark_without_a_successful_run
+    with_repositories do |tmpdir, _source, checkout, _initial_sha|
+      state_home = File.join(tmpdir, "state")
+      state_dir = File.join(state_home, "dotfiles")
+      FileUtils.mkdir_p(state_dir)
+      File.write(File.join(state_dir, "needs-run"), "dotf run\n")
+
+      run_check(checkout, state_home, nil)
+
+      assert File.exist?(File.join(state_dir, "needs-run"))
+    end
+  end
+
+  private
+
+  def with_repositories
+    Dir.mktmpdir("dotf-update-notice") do |tmpdir|
+      remote = File.join(tmpdir, "remote.git")
+      source = File.join(tmpdir, "source")
+      checkout = File.join(tmpdir, "checkout")
+      run_git(tmpdir, "init", "--bare", remote)
+      run_git(tmpdir, "init", "--initial-branch=main", source)
+      run_git(source, "config", "user.email", "test@example.com")
+      run_git(source, "config", "user.name", "Test")
+      initial_sha = commit_and_push(source, "initial", remote: remote)
+      run_git(tmpdir, "clone", "--branch", "main", remote, checkout)
+      yield tmpdir, source, checkout, initial_sha
+    end
+  end
+
+  def commit_and_push(source, message, remote: "origin")
+    File.write(File.join(source, "state"), message)
+    run_git(source, "add", "state")
+    run_git(source, "commit", "--no-gpg-sign", "-m", message)
+    run_git(source, "remote", "add", "origin", remote) unless remote == "origin"
+    run_git(source, "push", "origin", "main")
+    run_git(source, "rev-parse", "HEAD").strip
+  end
+
+  def run_check(checkout, state_home, last_run_sha)
+    state_dir = File.join(state_home, "dotfiles")
+    FileUtils.mkdir_p(state_dir)
+    File.write(File.join(state_dir, "last-run-sha"), "#{last_run_sha}\n") if last_run_sha
+    command = "source #{Shellwords.escape(FUNCTION_PATH)}; __dotf_refresh_update_notice"
+    output, status = Open3.capture2e(
+      {"DOTFILES_DIR" => checkout, "XDG_STATE_HOME" => state_home},
+      "fish", "--no-config", "--command", command
+    )
+    assert status.success?
+    assert_empty output
+  end
+
+  def run_git(directory, *arguments)
+    output, status = Open3.capture2e("git", "-C", directory, *arguments)
+    assert status.success?, output
+    output
+  end
+end
+# standard:enable Dotfiles/BanFileSystemClasses


### PR DESCRIPTION
## Summary
- record the applied commit after each successful `dotf run`
- refresh `origin/main` in a detached, throttled Fish process
- show a cached, copy-pasteable update command without delaying the prompt
- remove the unavailable Grok model from Pi model scoping

## Tests
- `bundle exec rake test`
- `mise run lint`
- Fish syntax and formatting checks