### PR TITLE
Remove stale try launcher during migration

### DIFF
--- a/lib/dotfiles/migrations/202608240004_remove_try_launcher.rb
+++ b/lib/dotfiles/migrations/202608240004_remove_try_launcher.rb
@@ -1,0 +1,11 @@
+class Dotfiles::Migration::RemoveTryLauncher < Dotfiles::Migration
+  VERSION = 202608240004
+
+  def up
+    @system.rm_rf(File.join(@home, ".local", "bin", "try"))
+  end
+
+  def down
+    raise NotImplementedError, "This migration removes the retired try launcher and cannot be safely reversed."
+  end
+end

--- a/test/dotfiles/remove_try_launcher_migration_test.rb
+++ b/test/dotfiles/remove_try_launcher_migration_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class RemoveTryLauncherMigrationTest < Minitest::Test
+  def test_removes_retired_launcher
+    launcher = File.join(@home, ".local", "bin", "try")
+    @fake_system.stub_file_content(launcher, "old launcher")
+
+    migration.up
+
+    refute @fake_system.file_exist?(launcher)
+  end
+
+  private
+
+  def migration
+    Dotfiles::Migration::RemoveTryLauncher.new(
+      dotfiles_dir: @dotfiles_dir,
+      home: @home,
+      system: @fake_system
+    )
+  end
+end


### PR DESCRIPTION
Follow-up to #595 and #549.

The local convergence proof found that whole-tree dotfile copying leaves a previously managed `~/.local/bin/try` in place after its source is deleted. That launcher shadows the new native mise binary.

This adds a one-way migration and regression test to remove it.

Validation:
- `mise run test` — 381 runs, 970 assertions
- `mise run lint`