### PR TITLE
Initialize try through its resolved native path

### DIFF
--- a/files/home/.bashrc
+++ b/files/home/.bashrc
@@ -109,8 +109,9 @@ if [[ -x /opt/homebrew/bin/mosh-server ]]; then
   alias mosh-mbp="mosh --server='SHELL=/opt/homebrew/bin/fish /opt/homebrew/bin/mosh-server' nateberkopec@MBP-Server.local"
 fi
 
-if command -v try >/dev/null 2>&1; then
-  eval "$(SHELL="$(command -v bash)" try init "$HOME/src/tries")"
+if try_bin="$(command -v try)"; then
+  eval "$(SHELL="$(command -v bash)" "$try_bin" init "$HOME/src/tries")"
+  unset try_bin
 fi
 
 if command -v starship >/dev/null 2>&1; then

--- a/files/home/.config/fish/config.fish
+++ b/files/home/.config/fish/config.fish
@@ -99,8 +99,8 @@ if test -f ~/.config/fish/private.fish
   source ~/.config/fish/private.fish
 end
 
-if command -q try
-  env SHELL=(status fish-path) try init ~/src/tries | source
+if set -l try_bin (command -s try)
+  env SHELL=(status fish-path) "$try_bin" init ~/src/tries | source
 end
 
 # starship prompt


### PR DESCRIPTION
Follow-up to #595 and #549.

Local convergence exposed an upstream Spinel behavior: when `try init` is invoked by a bare PATH command, the compiled binary expands `$0` relative to the current directory and generates a broken function such as `~/.dotfiles/try`.

Fish and Bash now resolve the mise executable first and invoke `init` through that absolute path. The resulting generated functions point directly to the native locked installation.

Validated both shell configs with opposite inherited `SHELL` values; both generated functions embed `~/.local/share/mise/installs/github-nateberkopec-try/1.10.1/try`.