### PR TITLE
Preinstall Playwright for agent browser tests

### DIFF
--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -105,7 +105,7 @@ jobs:
         NONINTERACTIVE: true
         AUBE_DISABLE_TARBALL_STREAM: "1"
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "gum,github:jdx/aube,npm:@earendil-works/pi-coding-agent,fzf,aqua:fish-shell/fish-shell"
+        MISE_CI_TOOLS: "gum,github:jdx/aube,npm:@earendil-works/pi-coding-agent,fzf,aqua:fish-shell/fish-shell,pipx,pipx:playwright"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_CASKS: ""
         DEBIAN_CI_PACKAGES: "trash-cli"
@@ -202,7 +202,7 @@ jobs:
         NONINTERACTIVE: true
         AUBE_DISABLE_TARBALL_STREAM: "1"
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "gum,github:jdx/aube,npm:@earendil-works/pi-coding-agent,fzf,aqua:fish-shell/fish-shell"
+        MISE_CI_TOOLS: "gum,github:jdx/aube,npm:@earendil-works/pi-coding-agent,fzf,aqua:fish-shell/fish-shell,pipx,pipx:playwright"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_CASKS: ""
       run: |

--- a/bin/lib/post-dotfiles-hook.sh
+++ b/bin/lib/post-dotfiles-hook.sh
@@ -7,8 +7,10 @@
 
 set -e
 
-# Keep the browser revision aligned with mise's pinned Playwright CLI. The
-# installer is a no-op when the matching browser is already cached.
+# The new config is copied after bootstrap's tool-install phase, so install
+# Playwright here before using it. These commands are no-ops once current.
+mise install pipx
+mise install pipx:playwright
 mise exec -- playwright install chromium-headless-shell
 
 [ "$(uname -s)" = "Darwin" ] || exit 0

--- a/bin/lib/post-dotfiles-hook.sh
+++ b/bin/lib/post-dotfiles-hook.sh
@@ -7,6 +7,10 @@
 
 set -e
 
+# Keep the browser revision aligned with mise's pinned Playwright CLI. The
+# installer is a no-op when the matching browser is already cached.
+mise exec -- playwright install chromium-headless-shell
+
 [ "$(uname -s)" = "Darwin" ] || exit 0
 
 legacy_wallpaper_label="com.user.woodblock-wallpaper"

--- a/bin/lib/post-dotfiles-hook.sh
+++ b/bin/lib/post-dotfiles-hook.sh
@@ -7,10 +7,8 @@
 
 set -e
 
-# The new config is copied after bootstrap's tool-install phase, so install
-# Playwright here before using it. These commands are no-ops once current.
-mise install pipx
-mise install pipx:playwright
+# Keep the browser revision aligned with mise's pinned Playwright CLI. The
+# installer is a no-op when the matching browser is already cached.
 mise exec -- playwright install chromium-headless-shell
 
 [ "$(uname -s)" = "Darwin" ] || exit 0

--- a/files/home/.claude/skills/webapp-testing/SKILL.md
+++ b/files/home/.claude/skills/webapp-testing/SKILL.md
@@ -6,6 +6,31 @@ license: Complete terms in LICENSE.txt
 
 # Web Application Testing
 
+## Discover Playwright before installing anything
+
+Check the executable first:
+
+```bash
+command -v playwright && playwright --version
+```
+
+Use that executable for supported commands such as `playwright screenshot`. Do not use `npx playwright`, pin an arbitrary Playwright version, or install browsers when the executable is already available. The managed CLI has a matching Chromium headless shell preinstalled in Playwright's standard browser cache.
+
+For custom automation, first test whether the active Python can import Playwright:
+
+```bash
+python3 -c 'import playwright'
+```
+
+If it cannot, use the Python interpreter beside the resolved managed CLI instead of installing another copy:
+
+```bash
+PLAYWRIGHT_PYTHON="$(dirname "$(realpath "$(command -v playwright)")")/python"
+"$PLAYWRIGHT_PYTHON" your_automation.py
+```
+
+Only install Playwright after `command -v playwright` fails. Do not treat a failed Python or Node import as proof that the CLI is unavailable.
+
 To test local web applications, write native Python Playwright scripts.
 
 **Helper Scripts Available**:

--- a/files/home/.config/mise/config.toml
+++ b/files/home/.config/mise/config.toml
@@ -11,6 +11,7 @@ hk = "1.56.0"
 "cargo:starship" = "1.26.0"
 "npm:@openai/codex" = { version = "0.149.0", depends = ["github:jdx/aube"] }
 "npm:sfw" = { version = "2.0.6", depends = ["github:jdx/aube"] }
+"pipx:playwright" = "1.62.0"
 "npm:@earendil-works/pi-coding-agent" = { version = "0.84.2", depends = ["github:jdx/aube"], minimum_release_age = "0d", aube_args = "--deny-build=@google/genai --deny-build=protobufjs" }
 "go:github.com/mikefarah/yq/v4" = "4.53.6"
 "go:github.com/noperator/yknotify" = "0.0.0-20260324103239-0c773bdadedb"

--- a/files/home/.config/mise/config.toml
+++ b/files/home/.config/mise/config.toml
@@ -11,7 +11,8 @@ hk = "1.56.0"
 "cargo:starship" = "1.26.0"
 "npm:@openai/codex" = { version = "0.149.0", depends = ["github:jdx/aube"] }
 "npm:sfw" = { version = "2.0.6", depends = ["github:jdx/aube"] }
-"pipx:playwright" = "1.62.0"
+pipx = "1.16.7"
+"pipx:playwright" = { version = "1.62.0", depends = ["pipx"] }
 "npm:@earendil-works/pi-coding-agent" = { version = "0.84.2", depends = ["github:jdx/aube"], minimum_release_age = "0d", aube_args = "--deny-build=@google/genai --deny-build=protobufjs" }
 "go:github.com/mikefarah/yq/v4" = "4.53.6"
 "go:github.com/noperator/yknotify" = "0.0.0-20260324103239-0c773bdadedb"

--- a/files/home/.config/mise/mise.lock
+++ b/files/home/.config/mise/mise.lock
@@ -400,6 +400,20 @@ backend = "npm:@openai/codex"
 version = "2.0.6"
 backend = "npm:sfw"
 
+[[tools.pipx]]
+version = "1.16.7"
+backend = "aqua:pypa/pipx"
+
+[tools.pipx."platforms.linux-x64"]
+checksum = "sha256:302633d0061e0ab4269257501cbe1338cde5f00f22f121543706624aada0145e"
+url = "https://github.com/pypa/pipx/releases/download/1.16.7/pipx.pyz"
+url_api = "https://api.github.com/repos/pypa/pipx/releases/assets/513588802"
+
+[tools.pipx."platforms.macos-arm64"]
+checksum = "sha256:302633d0061e0ab4269257501cbe1338cde5f00f22f121543706624aada0145e"
+url = "https://github.com/pypa/pipx/releases/download/1.16.7/pipx.pyz"
+url_api = "https://api.github.com/repos/pypa/pipx/releases/assets/513588802"
+
 [[tools."pipx:playwright"]]
 version = "1.62.0"
 backend = "pipx:playwright"

--- a/files/home/.config/mise/mise.lock
+++ b/files/home/.config/mise/mise.lock
@@ -400,6 +400,10 @@ backend = "npm:@openai/codex"
 version = "2.0.6"
 backend = "npm:sfw"
 
+[[tools."pipx:playwright"]]
+version = "1.62.0"
+backend = "pipx:playwright"
+
 [[tools.pkl]]
 version = "0.32.1"
 backend = "aqua:apple/pkl"

--- a/test/mise_bootstrap_packages_launchd_test.rb
+++ b/test/mise_bootstrap_packages_launchd_test.rb
@@ -40,6 +40,14 @@ class MiseBootstrapPackagesLaunchdTest < Minitest::Test
 
     assert_match(/\A\d+\.\d+\.\d+\z/, tools.fetch("ruby"))
     assert_match(/\A\d+\.\d+\.\d+\z/, tools.fetch("gum"))
+    assert_match(/\A\d+\.\d+\.\d+\z/, tools.fetch("pipx:playwright"))
+  end
+
+  def test_preinstalls_playwright_headless_shell
+    hook_path = File.expand_path("../bin/lib/post-dotfiles-hook.sh", __dir__)
+    hook = Dotfiles::SystemAdapter.new.read_file(hook_path)
+
+    assert_includes hook, "mise exec -- playwright install chromium-headless-shell"
   end
 
   private

--- a/test/mise_bootstrap_packages_launchd_test.rb
+++ b/test/mise_bootstrap_packages_launchd_test.rb
@@ -40,7 +40,9 @@ class MiseBootstrapPackagesLaunchdTest < Minitest::Test
 
     assert_match(/\A\d+\.\d+\.\d+\z/, tools.fetch("ruby"))
     assert_match(/\A\d+\.\d+\.\d+\z/, tools.fetch("gum"))
-    assert_match(/\A\d+\.\d+\.\d+\z/, tools.fetch("pipx:playwright"))
+    assert_match(/\A\d+\.\d+\.\d+\z/, tools.fetch("pipx"))
+    assert_match(/\A\d+\.\d+\.\d+\z/, tools.dig("pipx:playwright", "version"))
+    assert_equal ["pipx"], tools.dig("pipx:playwright", "depends")
   end
 
   def test_preinstalls_playwright_headless_shell

--- a/test/post_dotfiles_hook_test.rb
+++ b/test/post_dotfiles_hook_test.rb
@@ -15,6 +15,7 @@ class PostDotfilesHookTest < Minitest::Test
       FileUtils.mkdir_p([File.dirname(plist), bin])
       File.write(plist, "legacy")
       write_command(bin, "uname", "echo Darwin")
+      write_command(bin, "mise", "exit 0")
       write_command(bin, "launchctl", 'echo "$*" >> "$TRACE"')
 
       _stdout, stderr, status = Open3.capture3(

--- a/test/post_dotfiles_hook_test.rb
+++ b/test/post_dotfiles_hook_test.rb
@@ -9,23 +9,34 @@ class PostDotfilesHookTest < Minitest::Test
     Dir.mktmpdir do |dir|
       home = File.join(dir, "home")
       plist = File.join(home, "Library/LaunchAgents/com.user.woodblock-wallpaper.plist")
-      trace = File.join(dir, "launchctl.log")
+      launchctl_trace = File.join(dir, "launchctl.log")
+      mise_trace = File.join(dir, "mise.log")
       bin = File.join(dir, "bin")
 
       FileUtils.mkdir_p([File.dirname(plist), bin])
       File.write(plist, "legacy")
       write_command(bin, "uname", "echo Darwin")
-      write_command(bin, "mise", "exit 0")
-      write_command(bin, "launchctl", 'echo "$*" >> "$TRACE"')
+      write_command(bin, "mise", 'echo "$*" >> "$MISE_TRACE"')
+      write_command(bin, "launchctl", 'echo "$*" >> "$LAUNCHCTL_TRACE"')
 
       _stdout, stderr, status = Open3.capture3(
-        {"HOME" => home, "PATH" => "#{bin}:#{ENV.fetch("PATH")}", "TRACE" => trace},
+        {
+          "HOME" => home,
+          "PATH" => "#{bin}:#{ENV.fetch("PATH")}",
+          "LAUNCHCTL_TRACE" => launchctl_trace,
+          "MISE_TRACE" => mise_trace
+        },
         "bash", script
       )
 
       assert status.success?, stderr
       refute File.exist?(plist)
-      assert_equal "bootout gui/#{Process.uid}/com.user.woodblock-wallpaper\n", File.read(trace)
+      assert_equal "bootout gui/#{Process.uid}/com.user.woodblock-wallpaper\n", File.read(launchctl_trace)
+      assert_equal <<~TRACE, File.read(mise_trace)
+        install pipx
+        install pipx:playwright
+        exec -- playwright install chromium-headless-shell
+      TRACE
     end
   end
 

--- a/test/post_dotfiles_hook_test.rb
+++ b/test/post_dotfiles_hook_test.rb
@@ -32,11 +32,7 @@ class PostDotfilesHookTest < Minitest::Test
       assert status.success?, stderr
       refute File.exist?(plist)
       assert_equal "bootout gui/#{Process.uid}/com.user.woodblock-wallpaper\n", File.read(launchctl_trace)
-      assert_equal <<~TRACE, File.read(mise_trace)
-        install pipx
-        install pipx:playwright
-        exec -- playwright install chromium-headless-shell
-      TRACE
+      assert_equal "exec -- playwright install chromium-headless-shell\n", File.read(mise_trace)
     end
   end
 


### PR DESCRIPTION
## Summary

- manage the Playwright CLI through mise/pipx
- preinstall the CLI-matched Chromium headless shell during convergence
- teach the webapp-testing skill to discover and reuse the managed CLI before imports or `npx`
- use the managed Playwright virtualenv for native Python automation when the active Python cannot import Playwright

## Validation

- `mise run lint test`
- `python3 ~/.claude/skills/skill-creator/scripts/quick_validate.py files/home/.claude/skills/webapp-testing`
- `bash -n bin/lib/post-dotfiles-hook.sh`