### PR TITLE
Fix Fish dotfiles update notice

### DIFF
--- a/files/home/.config/fish/config.fish
+++ b/files/home/.config/fish/config.fish
@@ -22,7 +22,7 @@ function fish_greeting
         end
     end
 
-    command fish --no-config --command __dotf_refresh_update_notice >/dev/null 2>&1 &
+    command fish --no-config --command 'source "$__fish_config_dir/functions/__dotf_refresh_update_notice.fish"; __dotf_refresh_update_notice' >/dev/null 2>&1 &
     disown $last_pid 2>/dev/null
     return 0
 end

--- a/test/fish/dotf_update_notice_test.rb
+++ b/test/fish/dotf_update_notice_test.rb
@@ -4,6 +4,8 @@ require "tmpdir"
 
 # standard:disable Dotfiles/BanFileSystemClasses
 class DotfUpdateNoticeTest < Minitest::Test
+  GIT_ENV = ENV.keys.grep(/\AGIT_/).to_h { |name| [name, nil] }.freeze
+  CONFIG_PATH = File.expand_path("../../files/home/.config/fish/config.fish", __dir__)
   FUNCTION_PATH = File.expand_path("../../files/home/.config/fish/functions/__dotf_refresh_update_notice.fish", __dir__)
 
   def setup
@@ -16,6 +18,30 @@ class DotfUpdateNoticeTest < Minitest::Test
       run_check(checkout, File.join(tmpdir, "state"), initial_sha)
 
       assert File.exist?(File.join(tmpdir, "state", "dotfiles", "needs-run"))
+    end
+  end
+
+  def test_greeting_checks_for_changes_in_the_background
+    with_repositories do |tmpdir, source, checkout, initial_sha|
+      commit_and_push(source, "new change")
+      state_home = File.join(tmpdir, "state")
+      state_dir = File.join(state_home, "dotfiles")
+      home = File.join(tmpdir, "home")
+      function_dir = File.join(home, ".config", "fish", "functions")
+      FileUtils.mkdir_p(state_dir)
+      FileUtils.mkdir_p(function_dir)
+      File.write(File.join(state_dir, "last-run-sha"), "#{initial_sha}\n")
+      FileUtils.cp(FUNCTION_PATH, function_dir)
+
+      output, status = Open3.capture2e(
+        GIT_ENV.merge("DOTFILES_DIR" => checkout, "HOME" => home, "XDG_STATE_HOME" => state_home),
+        "fish", "--no-config", "--command", "source #{Shellwords.escape(CONFIG_PATH)}; fish_greeting"
+      )
+
+      assert status.success?, output
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+      sleep 0.01 until File.exist?(File.join(state_dir, "needs-run")) || Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+      assert File.exist?(File.join(state_dir, "needs-run"))
     end
   end
 
@@ -73,7 +99,7 @@ class DotfUpdateNoticeTest < Minitest::Test
     File.write(File.join(state_dir, "last-run-sha"), "#{last_run_sha}\n") if last_run_sha
     command = "source #{Shellwords.escape(FUNCTION_PATH)}; __dotf_refresh_update_notice"
     output, status = Open3.capture2e(
-      {"DOTFILES_DIR" => checkout, "XDG_STATE_HOME" => state_home},
+      GIT_ENV.merge("DOTFILES_DIR" => checkout, "XDG_STATE_HOME" => state_home),
       "fish", "--no-config", "--command", command
     )
     assert status.success?
@@ -81,7 +107,7 @@ class DotfUpdateNoticeTest < Minitest::Test
   end
 
   def run_git(directory, *arguments)
-    output, status = Open3.capture2e("git", "-C", directory, *arguments)
+    output, status = Open3.capture2e(GIT_ENV, "git", "-c", "core.hooksPath=/dev/null", "-C", directory, *arguments)
     assert status.success?, output
     output
   end


### PR DESCRIPTION
## Summary
- explicitly source the update-notice function in the detached `fish --no-config` process
- preserve the nonblocking greeting while allowing the background fetch to run
- add a regression test through the real greeting path and isolate its Git fixtures from parent hook state

## Root cause
`fish --no-config` has no autoload function path, so `__dotf_refresh_update_notice` was an unknown command. Its output and exit status were intentionally suppressed, making every greeting silently skip the fetch.

## Tests
- `HK=0 bundle exec rake test` (376 runs, 986 assertions)
- `bundle exec standardrb`
- complexity, dead-code, flog, flay, skills, and secrets checks
- Fish syntax check
- independent fresh-context review: no blockers