### PR TITLE
Remove dotf convergence announcement

### DIFF
--- a/bin/dotf
+++ b/bin/dotf
@@ -123,8 +123,6 @@ mise_packages_supported() {
 }
 
 run_mise_bootstrap() {
-    announce "Converging machine with mise bootstrap"
-
     local args=(-C "$HOME" bootstrap --yes --locked)
     local status
     if ! mise_packages_supported; then

--- a/test/dotfiles/dotf_cli_test.rb
+++ b/test/dotfiles/dotf_cli_test.rb
@@ -44,8 +44,7 @@ class DotfCliTest < Minitest::Test
       stdout, stderr, status, log = mise_bootstrap_result(tmpdir, script_path, admin: true)
 
       assert status.success?
-      assert_includes stdout, "Converging machine with mise bootstrap"
-      refute_includes stdout, "mise -C"
+      assert_empty stdout
       assert_empty stderr
       assert_equal "mise -C #{tmpdir}/home bootstrap --yes --locked --quiet\n", log
     end


### PR DESCRIPTION
## Summary
- stop printing the mise bootstrap convergence announcement during `dotf run`
- assert quiet bootstrap output in the CLI test

## Tests
- `bundle exec rake test` (376 runs, 984 assertions)