### PR TITLE
Pin pi-btw extension

### DIFF
--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -6,7 +6,7 @@
   "hideThinkingBlock": false,
   "packages": [
     "npm:pi-mcp-adapter@2.15.0",
-    "npm:@narumitw/pi-btw@0.55.4",
+    "npm:@narumitw/pi-btw@0.55.1",
     "npm:pi-ding@0.2.2",
     "npm:pi-subagents@0.37.2",
     "npm:pi-web-providers@3.5.1"

--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -6,6 +6,7 @@
   "hideThinkingBlock": false,
   "packages": [
     "npm:pi-mcp-adapter@2.15.0",
+    "npm:@narumitw/pi-btw@0.55.4",
     "npm:pi-ding@0.2.2",
     "npm:pi-subagents@0.37.2",
     "npm:pi-web-providers@3.5.1"


### PR DESCRIPTION
## Summary
- add `@narumitw/pi-btw` to Pi packages
- pin it at version `0.55.4`

## Verification
- parsed `files/home/.pi/agent/settings.json` as JSON
- pre-commit checks: 376 runs, 984 assertions, 0 failures