### PR TITLE
Add Pi fast mode extension

### DIFF
--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -6,6 +6,7 @@
   "hideThinkingBlock": false,
   "packages": [
     "npm:pi-mcp-adapter@2.15.0",
+    "git:github.com/nijaru/pi-fast-mode@85c8b67a4a3f823e33ab0217a55f37d15e6e6eca",
     "npm:pi-ding@0.2.2",
     "npm:pi-subagents@0.37.2",
     "npm:pi-web-providers@3.5.1"


### PR DESCRIPTION
## Summary

- add nijaru/pi-fast-mode as a commit-pinned Pi package
- enable `/fast` support for OpenAI Codex GPT-5.6 models, including Luna

## Verification

- installed the pinned Git package in an isolated HOME with Pi 0.84.2
- loaded Pi model discovery successfully with the extension enabled
- passed pre-commit lint, secrets, complexity, and full test suite (376 runs, 984 assertions)