### PR TITLE
Restrict Pi Fireworks models to US routers

### DIFF
--- a/files/home/.pi/agent/extensions/fireworks_intent.ts
+++ b/files/home/.pi/agent/extensions/fireworks_intent.ts
@@ -1,63 +1,106 @@
+import {
+	createProvider,
+	envApiKeyAuth,
+	openAICompletionsApi,
+	type Api,
+	type Context,
+	type Model,
+	type SimpleStreamOptions,
+	type StreamOptions,
+} from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const FIREWORKS_PROVIDER = "fireworks";
+const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
+const KIMI_K3_US = "accounts/fireworks/routers/kimi-k3-us";
+const GLM_5P2_FAST_US = "accounts/fireworks/routers/glm-5p2-fast-us";
+const US_ONLY_MODELS = new Set([KIMI_K3_US, GLM_5P2_FAST_US]);
 
-type FireworksAlias = {
-	targetModel: string;
-	serviceTier?: "priority";
-};
-
-type ProviderPayload = {
-	model?: unknown;
-	service_tier?: unknown;
-	[key: string]: unknown;
-};
-
-const MODEL_ALIASES: Record<string, FireworksAlias> = {
-	"kimi-k2p6": {
-		targetModel: "accounts/fireworks/models/kimi-k2p6",
-	},
-	"kimi-k2p6-priority": {
-		targetModel: "accounts/fireworks/models/kimi-k2p6",
-		serviceTier: "priority",
-	},
-	"kimi-k2p6-fast": {
-		targetModel: "accounts/fireworks/routers/kimi-k2p6-fast",
-	},
-	"glm-5p2": {
-		targetModel: "accounts/fireworks/models/glm-5p2",
-	},
-	"glm-5p2-priority": {
-		targetModel: "accounts/fireworks/models/glm-5p2",
-		serviceTier: "priority",
-	},
-};
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
+function assertUSOnlyModel(model: unknown): asserts model is string {
+	if (typeof model !== "string" || !US_ONLY_MODELS.has(model)) {
+		throw new Error(`Blocked non-US Fireworks model: ${String(model)}`);
+	}
 }
 
-function rewrittenPayload(payload: ProviderPayload, alias: FireworksAlias) {
-	const { service_tier: _serviceTier, ...rest } = payload;
+const fireworksApi = openAICompletionsApi();
+const guardedApi = {
+	stream(model: Model<Api>, context: Context, options?: StreamOptions) {
+		assertUSOnlyModel(model.id);
+		return fireworksApi.stream(model, context, options);
+	},
+	streamSimple(model: Model<Api>, context: Context, options?: SimpleStreamOptions) {
+		assertUSOnlyModel(model.id);
+		return fireworksApi.streamSimple(model, context, options);
+	},
+};
 
-	return {
-		...rest,
-		model: alias.targetModel,
-		...(alias.serviceTier ? { service_tier: alias.serviceTier } : {}),
-	};
-}
+const models = [
+	{
+		id: KIMI_K3_US,
+		name: "Kimi K3 (Fireworks US-only)",
+		api: "openai-completions" as const,
+		provider: FIREWORKS_PROVIDER,
+		baseUrl: FIREWORKS_BASE_URL,
+		reasoning: true,
+		input: ["text", "image"] as const,
+		cost: {
+			input: 3.3,
+			cacheRead: 0.33,
+			cacheWrite: 0,
+			output: 16.5,
+		},
+		contextWindow: 1_048_576,
+		maxTokens: 131_072,
+		compat: {
+			supportsStore: false,
+			supportsDeveloperRole: false,
+			sendSessionAffinityHeaders: true,
+			supportsLongCacheRetention: false,
+			requiresReasoningContentOnAssistantMessages: true,
+			thinkingFormat: "openai" as const,
+			deferredToolsMode: "kimi" as const,
+		},
+	},
+	{
+		id: GLM_5P2_FAST_US,
+		name: "GLM 5.2 Fast (Fireworks US-only)",
+		api: "openai-completions" as const,
+		provider: FIREWORKS_PROVIDER,
+		baseUrl: FIREWORKS_BASE_URL,
+		reasoning: true,
+		input: ["text"] as const,
+		cost: {
+			input: 2.1,
+			cacheRead: 0.21,
+			cacheWrite: 0,
+			output: 6.6,
+		},
+		contextWindow: 1_048_575,
+		maxTokens: 131_072,
+		compat: {
+			supportsStore: false,
+			supportsDeveloperRole: false,
+			sendSessionAffinityHeaders: true,
+			supportsLongCacheRetention: false,
+		},
+	},
+];
 
 export default function (pi: ExtensionAPI) {
+	pi.registerProvider(createProvider({
+		id: FIREWORKS_PROVIDER,
+		name: "Fireworks US-only",
+		baseUrl: FIREWORKS_BASE_URL,
+		auth: {
+			apiKey: envApiKeyAuth("Fireworks API key", ["FIREWORKS_API_KEY"]),
+		},
+		models,
+		api: guardedApi,
+	}));
+
 	pi.on("before_provider_request", (event, ctx) => {
 		if (ctx.model?.provider !== FIREWORKS_PROVIDER) return;
-		if (!isRecord(event.payload)) return;
-
-		const payload = event.payload as ProviderPayload;
-		if (typeof payload.model !== "string") return;
-
-		const alias = MODEL_ALIASES[payload.model];
-		if (!alias) return;
-
-		return rewrittenPayload(payload, alias);
+		const payload = event.payload as { model?: unknown };
+		assertUSOnlyModel(payload.model);
 	});
 }

--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -27,7 +27,7 @@
   "enabledModels": [
     "openai-codex/gpt-5.6-sol:medium",
     "openai-codex/gpt-5.6-terra:xhigh",
-    "fireworks/glm-5p2-priority"
+    "fireworks/accounts/fireworks/routers/glm-5p2-fast-us"
   ],
   "subagents": {
     "agentOverrides": {


### PR DESCRIPTION
## Summary
- replace Pi's Fireworks catalog with the two documented US-only serverless routers
- block non-US Fireworks model IDs before provider requests
- scope model cycling to the US-only GLM router

## Validation
- `pi --list-models fireworks` lists exactly the two US-only routers
- a non-US custom Fireworks model is blocked before HTTP
- the US-only GLM router completed a live request
- `mise run lint`
- `mise run test`