### PR TITLE
Remove the large-files lint

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -31,11 +31,6 @@ description = "Run Ruby complexity checks"
 sources = ["**/*.rb", "!tmp/**", "!vendor/**", "!.pi-subagents/**", ".rubocop-custom.yml"]
 run = "bundle exec rubocop --config .rubocop-custom.yml --only Metrics/PerceivedComplexity"
 
-[tasks."lint:large-files"]
-description = "Check staged files for large files"
-sources = [".git/index"]
-run = '''git diff --cached --numstat --diff-filter=ACMR | awk -F '\t' '$1 ~ /^[0-9]+$/ && $1 > 100 { print "You are adding more than 100 lines to a file: " $3 " (+" $1 "). This is rarely necessary; consider simplifying the code. Is this the most YAGNI solution? Commit with --no-verify if needed."; bad=1 } END { exit bad }' '''
-
 [tasks."lint:human-only"]
 description = "Check staged files for human-only paths"
 sources = [".git/index", "tools/check_human_only_files.rb"]
@@ -67,7 +62,7 @@ run = "ruby tools/lint_agent_skills.rb"
 
 [tasks.lint]
 description = "Run all lint checks"
-depends = ["lint:standard", "lint:complexity", "lint:large-files", "lint:human-only", "lint:secrets", "lint:dead-code", "lint:flog", "lint:flay", "lint:skills"]
+depends = ["lint:standard", "lint:complexity", "lint:human-only", "lint:secrets", "lint:dead-code", "lint:flog", "lint:flay", "lint:skills"]
 
 [tasks.test]
 description = "Run the test suite"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,6 @@ Lints enforced on this codebase via `hk`/git hooks:
 
 - `standard`: Runs `standardrb`, including custom cops that prefer `SystemAdapter` over direct filesystem classes and keep Step public methods constrained.
 - `complexity`: Runs RuboCop's `Metrics/PerceivedComplexity` using `.rubocop-custom.yml`.
-- `large-files`: Checks files for the staged line-addition limit before commit.
 - `secrets`: Runs `gitleaks` over the working tree with repo config and redacted output.
 - `dead-code`: Runs the custom dead-code checker for unused Ruby methods, honoring `.debride-whitelist`.
 - `flog`: Fails if any Ruby method's flog complexity reaches the configured threshold, which is 25 by default.

--- a/files/home/.claude/skills/dev-env-setup/SKILL.md
+++ b/files/home/.claude/skills/dev-env-setup/SKILL.md
@@ -24,7 +24,7 @@ Never read or store plaintext credentials. Use fnox/1Password runtime references
 Read only the branch needed:
 
 - For mise and environment configuration, read [references/mise-and-hooks.md](references/mise-and-hooks.md).
-- For the standard task set, read [references/standard-tasks.md](references/standard-tasks.md); for aliases, serve behavior, test runtime, and large-file checks, read [references/project-commands.md](references/project-commands.md); for hooks, read [references/hk-hooks.md](references/hk-hooks.md).
+- For the standard task set, read [references/standard-tasks.md](references/standard-tasks.md); for aliases, serve behavior, and test runtime, read [references/project-commands.md](references/project-commands.md); for hooks, read [references/hk-hooks.md](references/hk-hooks.md).
 - For gitleaks, baselines, secret handling, and GitHub Actions, read [references/security-and-ci.md](references/security-and-ci.md). Baseline generation must use `--redact=75`; confirm the report contains no recovered values before committing it.
 - For Ruby dependencies, Standard, complexity, dead-code, flog, flay, and Bundler preparation, read [references/ruby-projects.md](references/ruby-projects.md).
 

--- a/files/home/.claude/skills/dev-env-setup/references/hk-hooks.md
+++ b/files/home/.claude/skills/dev-env-setup/references/hk-hooks.md
@@ -19,9 +19,6 @@ hooks {
       ["lint"] {
         check = "mise run lint:standard"
       }
-      ["large-files"] {
-        check = "mise run lint:large-files"
-      }
       ["secrets"] {
         check = "mise run lint:secrets"
       }

--- a/files/home/.claude/skills/dev-env-setup/references/project-commands.md
+++ b/files/home/.claude/skills/dev-env-setup/references/project-commands.md
@@ -56,17 +56,3 @@ Acceptable remediations for a slow test task are:
 - add or use a `test:fast` task that still covers 100% of the app's unit-level coverage;
 - keep the warning if neither approach can get the task under 10 seconds.
 
-### 7. Large File Check
-
-Pre-commit must include a large-file check so commits do not casually add too many lines to one file.
-
-Add a dedicated mise task named `lint:large-files` that checks staged files:
-
-```toml
-[tasks."lint:large-files"]
-description = "Check staged files for large files"
-sources = [".git/index"]
-run = '''git diff --cached --numstat --diff-filter=ACMR | awk -F '\t' '$1 ~ /^[0-9]+$/ && $1 > 100 { print "You are adding more than 100 lines to a file: " $3 " (+" $1 "). This is rarely necessary; consider simplifying the code. Is this the most YAGNI solution? Commit with --no-verify if needed."; bad=1 } END { exit bad }' '''
-```
-
-Keep this check self-contained in the mise task. It fails when a commit stages more than 100 added lines in any added, copied, modified, or renamed file. Existing files over 100 lines are fine unless the current staged change adds more than 100 lines to that file. There is no project script or override environment variable; use the normal `--no-verify` escape hatch if needed.

--- a/files/home/.claude/skills/dev-env-setup/references/standard-tasks.md
+++ b/files/home/.claude/skills/dev-env-setup/references/standard-tasks.md
@@ -22,7 +22,6 @@ For lint and test tasks, add `sources` so mise can skip unchanged checks during 
 | `lint:complexity` | `["**/*.rb", ".rubocop-custom.yml"]` |
 | `lint:dead-code` | `["**/*.rb", "**/*.rake", "bin/*", "Rakefile", ".debride-whitelist", "tools/check_dead_code.rb"]` |
 | `lint:flog` / `lint:flay` | `["**/*.rb", "Rakefile"]` |
-| `lint:large-files` | `[".git/index"]` so staging changes rerun the check |
 
 Example mise tasks section:
 
@@ -34,17 +33,12 @@ run = "bundle exec rake test"
 
 [tasks.lint]
 description = "Run all lint checks"
-depends = ["lint:standard", "lint:large-files", "lint:secrets", "lint:complexity", "lint:dead-code", "lint:flog", "lint:flay"]
+depends = ["lint:standard", "lint:secrets", "lint:complexity", "lint:dead-code", "lint:flog", "lint:flay"]
 
 [tasks."lint:standard"]
 description = "Run standardrb"
 sources = ["**/*.rb", ".standard.yml"]
 run = "bundle exec standardrb"
-
-[tasks."lint:large-files"]
-description = "Check staged files for large files"
-sources = [".git/index"]
-run = '''git diff --cached --numstat --diff-filter=ACMR | awk -F '\t' '$1 ~ /^[0-9]+$/ && $1 > 100 { print "You are adding more than 100 lines to a file: " $3 " (+" $1 "). This is rarely necessary; consider simplifying the code. Is this the most YAGNI solution? Commit with --no-verify if needed."; bad=1 } END { exit bad }' '''
 
 [tasks."lint:complexity"]
 description = "Run Ruby complexity checks"

--- a/files/home/.claude/skills/dev-env-setup/scripts/check-dev-env/hk.fish
+++ b/files/home/.claude/skills/dev-env-setup/scripts/check-dev-env/hk.fish
@@ -21,7 +21,6 @@ function check_hk_precommit
     end
 
     report_flag has_precommit_lint "pre-commit: lint step" check_fail "Add a lint step to pre-commit in hk config. Use: check = \"mise run lint\""
-    report_flag has_precommit_large_files "pre-commit: large-files step" check_fail "Add a pre-commit step to hk config. Use: check = \"mise run lint:large-files\""
 
     if test $is_ruby_project -eq 1
         report_flag has_precommit_complexity "pre-commit: complexity step" check_fail "Add a pre-commit step to hk config. Use: check = \"mise run lint:complexity\""
@@ -34,7 +33,7 @@ function check_hk_precommit
 end
 
 function collect_hk_flags
-    for flag in lint large_files complexity dead_code flog flay test
+    for flag in lint complexity dead_code flog flay test
         set -g has_precommit_$flag 0
     end
 
@@ -44,7 +43,6 @@ function collect_hk_flags
 
     set hk_contents (cat "$hk_file")
     set_hk_flag has_precommit_lint '(lint|standard|eslint|rubocop|clippy|ruff|biome)' "$hk_contents"
-    set_hk_flag has_precommit_large_files 'mise run lint:large-files' "$hk_contents"
     set_hk_flag has_precommit_complexity 'mise run lint:complexity' "$hk_contents"
     set_hk_flag has_precommit_dead_code 'mise run lint:dead-code' "$hk_contents"
     set_hk_flag has_precommit_flog 'mise run lint:flog' "$hk_contents"

--- a/files/home/.claude/skills/dev-env-setup/scripts/check-dev-env/mise-task-checks.fish
+++ b/files/home/.claude/skills/dev-env-setup/scripts/check-dev-env/mise-task-checks.fish
@@ -45,7 +45,3 @@ function check_long_mise_run_blocks
     set long_run_list (string join ", " $long_run_tasks)
     check_fail "mise task run blocks <= 10 lines" "Move long task run blocks to separate scripts, e.g. bin/<task> or scripts/<task>, and have mise call the script: $long_run_list"
 end
-
-function check_large_file_tooling
-    report_flag has_large_files "mise task: lint:large-files" check_fail "Add a self-contained [tasks.\"lint:large-files\"] section that checks files with more than 100 staged additions."
-end

--- a/files/home/.claude/skills/dev-env-setup/scripts/check-dev-env/mise-tasks.fish
+++ b/files/home/.claude/skills/dev-env-setup/scripts/check-dev-env/mise-tasks.fish
@@ -2,14 +2,13 @@ function check_mise_tasks
     collect_mise_task_flags
     report_standard_mise_tasks
     check_long_mise_run_blocks
-    check_large_file_tooling
     detect_ruby_project
     check_ruby_mise_tasks
     check_mise_modern_features
 end
 
 function collect_mise_task_flags
-    for flag in test lint large_files complexity dead_code flog flay serve_or_dev serve_task build
+    for flag in test lint complexity dead_code flog flay serve_or_dev serve_task build
         set -g has_$flag 0
     end
 
@@ -39,7 +38,7 @@ function mark_mise_task
     end
 
     set normalized_task_name (string replace -r '^lint:' '' -- "$task_name")
-    if contains -- "$normalized_task_name" large-files complexity dead-code flog flay
+    if contains -- "$normalized_task_name" complexity dead-code flog flay
         set flag_name (string replace -- - _ "$normalized_task_name")
         set -g has_$flag_name 1
     end

--- a/hk.pkl
+++ b/hk.pkl
@@ -9,9 +9,6 @@ hooks {
       ["complexity"] {
         check = "mise run lint:complexity"
       }
-      ["large-files"] {
-        check = "mise run lint:large-files"
-      }
       ["human-only"] {
         check = "mise run lint:human-only"
       }

--- a/test/skills/dev_env_mise_task_flags_test.rb
+++ b/test/skills/dev_env_mise_task_flags_test.rb
@@ -11,7 +11,7 @@ class DevEnvMiseTaskFlagsTest < Minitest::Test
   end
 
   def test_allowlisted_families_pass_in_bare_and_lint_forms
-    families = %w[large-files complexity dead-code flog flay]
+    families = %w[complexity dead-code flog flay]
 
     ["", "lint:"].each do |prefix|
       output = run_checker(families.map { |family| "#{prefix}#{family}" })
@@ -21,10 +21,10 @@ class DevEnvMiseTaskFlagsTest < Minitest::Test
   end
 
   def test_generic_lint_and_unrelated_tasks_do_not_enable_family_checks
-    families = %w[large-files complexity dead-code flog flay]
+    families = %w[complexity dead-code flog flay]
 
     %w[lint lint:flog-extra].each do |lint_task|
-      output = run_checker([lint_task, "docs", "large_files"])
+      output = run_checker([lint_task, "docs"])
 
       assert_report output, "PASS", "mise task: lint"
       families.each { |family| assert_report output, "FAIL", "mise task: lint:#{family}" }


### PR DESCRIPTION
## Why

The `lint:large-files` check (fail a commit that adds more than 100 lines to any one file) is too blunt an instrument. It never really got used or paid attention to; the outcome was always `--no-verify`.

## What

- `.mise.toml`: drop the `lint:large-files` task and its entry in `lint`'s `depends`.
- `hk.pkl`: drop the `large-files` pre-commit step.
- `AGENTS.md`: drop it from the list of enforced lints.
- `dev-env-setup` skill: remove the requirement from `SKILL.md`, the `project-commands.md` section, the `standard-tasks.md` table row and examples, and the `hk-hooks.md` example step. The checker no longer reports `mise task: lint:large-files` or `pre-commit: large-files step`.
- `test/skills/dev_env_mise_task_flags_test.rb`: drop `large-files` from the checked task families.

`mise run lint` and `mise run test` (382 runs, 0 failures) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZ74aziyqzgero5e1oVTWZ
