### PR TITLE
Upgrade Aube from its new repository

### DIFF
--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -105,7 +105,7 @@ jobs:
         NONINTERACTIVE: true
         AUBE_DISABLE_TARBALL_STREAM: "1"
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "gum,github:jdx/aube,npm:@earendil-works/pi-coding-agent,fzf,aqua:fish-shell/fish-shell,pipx,pipx:playwright"
+        MISE_CI_TOOLS: "gum,github:aubepkg/aube,npm:@earendil-works/pi-coding-agent,fzf,aqua:fish-shell/fish-shell,pipx,pipx:playwright"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_CASKS: ""
         DEBIAN_CI_PACKAGES: "trash-cli"
@@ -202,7 +202,7 @@ jobs:
         NONINTERACTIVE: true
         AUBE_DISABLE_TARBALL_STREAM: "1"
         GITHUB_TOKEN: ${{ github.token }}
-        MISE_CI_TOOLS: "gum,github:jdx/aube,npm:@earendil-works/pi-coding-agent,fzf,aqua:fish-shell/fish-shell,pipx,pipx:playwright"
+        MISE_CI_TOOLS: "gum,github:aubepkg/aube,npm:@earendil-works/pi-coding-agent,fzf,aqua:fish-shell/fish-shell,pipx,pipx:playwright"
         BREW_CI_PACKAGES: "duti"
         BREW_CI_CASKS: ""
       run: |

--- a/config/dependency-updater.yml
+++ b/config/dependency-updater.yml
@@ -28,9 +28,6 @@ snoozes:
   standard:
     candidate: "1.56.0"
     wake_at: "1.57.0"
-  "github:jdx/aube":
-    candidate: "2.2.0"
-    wake_at: "2.3.0"
   fnox:
     candidate: "1.34.1"
     wake_at: "1.35.0"

--- a/files/home/.config/mise/config.toml
+++ b/files/home/.config/mise/config.toml
@@ -2,18 +2,18 @@
 [tools]
 ruby = "4.0.6"
 node = "26.8.1"
-"github:jdx/aube" = "1.36.0"
+"github:aubepkg/aube" = "2.2.4"
 go = "1.27.0"
 rust = "1.98.0"
 hk = "1.56.1"
 "cargo:broot" = "1.59.0"
 "cargo:difftastic" = "0.70.0"
 "cargo:starship" = "1.26.0"
-"npm:@openai/codex" = { version = "0.151.0", depends = ["github:jdx/aube"] }
-"npm:sfw" = { version = "2.0.6", depends = ["github:jdx/aube"] }
+"npm:@openai/codex" = { version = "0.151.0", depends = ["github:aubepkg/aube"] }
+"npm:sfw" = { version = "2.0.6", depends = ["github:aubepkg/aube"] }
 pipx = "1.16.7"
 "pipx:playwright" = { version = "1.62.0", depends = ["pipx"] }
-"npm:@earendil-works/pi-coding-agent" = { version = "0.84.4", depends = ["github:jdx/aube"], minimum_release_age = "0d", aube_args = "--deny-build=@google/genai --deny-build=protobufjs" }
+"npm:@earendil-works/pi-coding-agent" = { version = "0.84.4", depends = ["github:aubepkg/aube"], minimum_release_age = "0d", aube_args = "--deny-build=@google/genai --deny-build=protobufjs" }
 "go:github.com/mikefarah/yq/v4" = "4.53.6"
 "go:github.com/noperator/yknotify" = "0.0.0-20260324103239-0c773bdadedb"
 "github:aldanial/cloc" = { version = "2.10", asset_pattern = "cloc-{{version}}.pl", bin = "cloc" }
@@ -41,7 +41,7 @@ pkl = "0.32.1"
 claude = "2.1.220"
 gitleaks = "8.30.1"
 "1password-cli" = "2.39.0"
-heroku = { version = "11.10.0", depends = ["github:jdx/aube"], aube_args = "--deny-build=cpu-features --deny-build=protobufjs --deny-build=ssh2 --deny-build=yarn" }
+heroku = { version = "11.10.0", depends = ["github:aubepkg/aube"], aube_args = "--deny-build=cpu-features --deny-build=protobufjs --deny-build=ssh2 --deny-build=yarn" }
 "github:rawnly/splash-cli" = "4.1.7"
 
 [tools."github:nateberkopec/try"]

--- a/files/home/.config/mise/mise.lock
+++ b/files/home/.config/mise/mise.lock
@@ -188,22 +188,19 @@ checksum = "sha256:bf59272455172108072a0a106379f7509fd4349bdcfd85203bac038ccd286
 url = "https://github.com/AlDanial/cloc/releases/download/v2.10/cloc-2.10.pl"
 url_api = "https://api.github.com/repos/AlDanial/cloc/releases/assets/466555197"
 
-[[tools."github:jdx/aube"]]
-version = "1.36.0"
-backend = "github:jdx/aube"
+[[tools."github:aubepkg/aube"]]
+version = "2.2.4"
+backend = "github:aubepkg/aube"
 
-[tools."github:jdx/aube"."platforms.linux-x64"]
-checksum = "sha256:0eb721d9ff37e24bf035f9a7cb62107593f59bd740393b2eee5b36a50e7759fb"
-url = "https://github.com/jdx/aube/releases/download/v1.36.0/aube-v1.36.0-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/494405804"
-provenance = "github-attestations"
+[tools."github:aubepkg/aube"."platforms.linux-x64"]
+checksum = "sha256:20b8fda0f9f471500ee64814880bd84c1bc402ee7f6dece39bfae25cc93aa1d8"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.4/aube-v2.2.4-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/538149375"
 
-[tools."github:jdx/aube"."platforms.macos-arm64"]
-checksum = "sha256:b169f6e78b081595ca738b105ba6a23d0cf87b499b7eca812203cc1615e0e5fe"
-url = "https://github.com/jdx/aube/releases/download/v1.36.0/aube-v1.36.0-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/494475875"
-provenance = "github-attestations"
-provenance_verified = true
+[tools."github:aubepkg/aube"."platforms.macos-arm64"]
+checksum = "sha256:aa3f6e8e319c8d9c92393e797cd5576229eacc0740e8cf2b34d4c65bb1e61708"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.4/aube-v2.2.4-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/538155490"
 
 [[tools."github:nateberkopec/print-label"]]
 version = "0.3.0"

--- a/lib/dotfiles/migrations/202605310002_reinstall_npm_mise_tools_with_aube.rb
+++ b/lib/dotfiles/migrations/202605310002_reinstall_npm_mise_tools_with_aube.rb
@@ -1,7 +1,7 @@
 class Dotfiles::Migration::ReinstallNpmMiseToolsWithAube < Dotfiles::Migration
   VERSION = 202605310002
 
-  AUBE_TOOL = "github:jdx/aube"
+  AUBE_TOOL = "github:aubepkg/aube"
 
   MISE_TOOLS = [
     "npm:@openai/codex",

--- a/test/dotfiles/migration_test.rb
+++ b/test/dotfiles/migration_test.rb
@@ -51,7 +51,7 @@ class MigrationTest < Minitest::Test
 
     migration.up
 
-    assert_executed!("MISE_NPM_PACKAGE_MANAGER=aube mise --cd #{@home} x github:jdx/aube -- mise --cd #{@home} install --yes heroku")
+    assert_executed!("MISE_NPM_PACKAGE_MANAGER=aube mise --cd #{@home} x github:aubepkg/aube -- mise --cd #{@home} install --yes heroku")
   end
 
   def test_hk_hook_migration_skips_absent_legacy_config


### PR DESCRIPTION
## Summary

- move the managed Aube tool from `github:jdx/aube` to `github:aubepkg/aube`
- upgrade Aube from 1.36.0 to 2.2.4
- regenerate the Linux and macOS lock entries from the new release assets
- update Aube dependency references and remove the obsolete 2.2.0 snooze

The old repository moved and its artifact attestations stopped resolving for clean Linux installs. The new lock entries retain exact SHA-256 checksums for both supported platforms. GitHub attestations are not currently available for these transferred release assets.

Aube 2.x moves direct `aube add -g` installs to Aube’s own data root. These dotfiles install npm tools through mise rather than direct Aube global installs, so no global-package migration is required.

## Testing

- `bundle exec rake test`
- `mise run lint`
- clean locked Aube 2.2.4 install on macOS ARM64
- clean locked Aube 2.2.4 install on Linux x64 using `jdxcode/mise:2026.8.14`

Related to #620.