### PR TITLE
Configure Vertex AI US endpoint for Pi

### DIFF
--- a/files/home/.pi/agent/models.json
+++ b/files/home/.pi/agent/models.json
@@ -2,6 +2,19 @@
   "providers": {
     "openrouter": {
       "baseUrl": "https://us.openrouter.ai/api/v1"
+    },
+    "google-vertex": {
+      "baseUrl": "https://aiplatform.us.rep.googleapis.com",
+      "models": [
+        {
+          "id": "gemini-3.8-flash",
+          "name": "Gemini 3.8 Flash (Vertex US)",
+          "reasoning": true,
+          "input": ["text", "image"],
+          "contextWindow": 1048576,
+          "maxTokens": 65536
+        }
+      ]
     }
   }
 }

--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -27,7 +27,8 @@
   "enabledModels": [
     "openai-codex/gpt-5.6-sol:medium",
     "openai-codex/gpt-5.6-terra:xhigh",
-    "fireworks/accounts/fireworks/routers/glm-5p2-fast-us"
+    "fireworks/accounts/fireworks/routers/glm-5p2-fast-us",
+    "google-vertex/gemini-3.8-flash:high"
   ],
   "subagents": {
     "agentOverrides": {


### PR DESCRIPTION
## Summary
- route Pi’s Google Vertex provider through the US multi-region endpoint
- add Gemini 3.8 Flash with its context and output limits
- include the model in Pi’s enabled model scope

## Validation
- validated `models.json` and `settings.json` with `jq`
- pre-commit hooks passed