### PR TITLE
Configure Dock autohide and position

### DIFF
--- a/files/home/.config/mise/config.toml
+++ b/files/home/.config/mise/config.toml
@@ -145,6 +145,8 @@ NSBrowserColumnAnimationSpeedMultiplier = 0
 ReduceMotionEnabled = 1
 
 [bootstrap.macos.defaults."com.apple.dock"]
+autohide = true
+orientation = "left"
 autohide-time-modifier = 0
 autohide-delay = 0
 springboard-show-duration = 0

--- a/test/mise_bootstrap_dotfiles_defaults_test.rb
+++ b/test/mise_bootstrap_dotfiles_defaults_test.rb
@@ -17,6 +17,8 @@ class MiseBootstrapDotfilesDefaultsTest < Minitest::Test
 
     assert_equal 0, defaults.dig("NSGlobalDomain", "NSAutomaticWindowAnimationsEnabled")
     assert_equal 2.0, defaults.dig("NSGlobalDomain", "com.apple.mouse.scaling")
+    assert_equal true, defaults.dig("com.apple.dock", "autohide")
+    assert_equal "left", defaults.dig("com.apple.dock", "orientation")
     assert_equal "scale", defaults.dig("com.apple.dock", "mineffect")
     assert_equal 1, defaults.dig("com.apple.AppleMultitouchTrackpad", "TrackpadRightClick")
     assert_equal false, defaults.dig("com.apple.spaces", "spans-displays")


### PR DESCRIPTION
## Summary
- enable Dock autohide through declarative macOS defaults
- position the Dock on the left
- verify both settings in the bootstrap defaults test

## Testing
- `bundle exec ruby -Itest test/mise_bootstrap_dotfiles_defaults_test.rb`

## Notes
- The local complexity pre-commit hook scanned unrelated untracked `.claude/worktrees/*/vendor` files and failed there. The targeted test passes, and CI will run against a clean checkout.