### PR TITLE
Exclude developer caches from Time Machine

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -44,7 +44,8 @@ time_machine_settings:
   requires_ac_power: false
   exclusions:
   - "~/Documents/Code.nosync"
-  - "~/.cache/huggingface"
+  - "~/.bun/install/cache"
+  - "~/.cache"
   - "~/.npm"
   - "~/Library/pnpm"
   - "~/.local/share/mise"


### PR DESCRIPTION
## Summary

- exclude Bun's install cache from Time Machine
- exclude the complete XDG cache directory instead of only its Hugging Face child

## Why

A Time Machine backup spent at least 8 hours and 40 minutes processing `~/.bun/install/cache`, advancing from 11% to 12% at roughly 1.5 items per second.

The audited paths contain:

- `~/.bun/install/cache`: 456,820 entries / 5.2 GB
- `~/.cache`: 439,352 entries / 49 GB

Both contain reproducible cache data. Existing exclusions already cover npm, pnpm, and mise stores.

## Validation

- `git diff --check`
- parsed `config/config.yml` with Ruby YAML
- `mise run test` — 408 runs, 1,065 assertions, 0 failures
