### PR TITLE
Refresh Time Machine exclusions before validation

### DIFF
--- a/lib/dotfiles/steps/mac/configure_time_machine_step.rb
+++ b/lib/dotfiles/steps/mac/configure_time_machine_step.rb
@@ -95,7 +95,7 @@ class Dotfiles::Step::ConfigureTimeMachineStep < Dotfiles::Step
   end
 
   def skip_paths
-    @skip_paths ||= defaults_read("SkipPaths").to_s
+    defaults_read("SkipPaths").to_s
   end
 
   def defaults_bool(value)

--- a/test/dotfiles/steps/configure_time_machine_step_test.rb
+++ b/test/dotfiles/steps/configure_time_machine_step_test.rb
@@ -56,6 +56,18 @@ class ConfigureTimeMachineStepTest < StepTestCase
     assert_incomplete
   end
 
+  def test_complete_after_run_adds_missing_exclusions
+    @fake_system.stub_macos
+    write_time_machine_config
+    stub_time_machine_defaults(skip_paths: [expanded_exclusions.first])
+
+    assert_should_run
+    step.run
+    stub_time_machine_defaults
+
+    assert_complete
+  end
+
   private
 
   def write_time_machine_config(overrides = {})


### PR DESCRIPTION
## Summary

- read Time Machine's `SkipPaths` fresh for every completion check
- add a regression test covering exclusions added between the pre-run and post-run checks

## Root cause

The Time Machine step memoized `SkipPaths` during `should_run?`. After the step added missing exclusions, final validation reused the pre-run value and falsely reported that installation had failed.

## Validation

- regression test failed before the fix with the missing-exclusion error
- `bundle exec ruby -Itest test/dotfiles/steps/configure_time_machine_step_test.rb`
- `mise run test` — 409 runs, 1,067 assertions, 0 failures
- StandardRB and complexity checks on both changed files
- `git diff --check`
