### PR TITLE
Automate morning Time Machine backups

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -41,7 +41,8 @@ spotlight_settings:
 time_machine_settings:
   auto_backup: true
   auto_backup_interval_seconds: 86400
-  requires_ac_power: false
+  requires_ac_power: true
+  wake_time: "05:15:00"
   exclusions:
   - "~/Documents/Code.nosync"
   - "~/.bun/install/cache"

--- a/files/home/.config/mise/config.toml
+++ b/files/home/.config/mise/config.toml
@@ -176,6 +176,13 @@ spans-displays = false
 raycastGlobalHotkey = "Command-49"
 onboarding_setupHotkey = true
 
+[bootstrap.macos.launchd.agents.time-machine-backup]
+program = "~/.local/share/dotfiles/run-time-machine-backup.fish"
+environment = { PATH = "{{env.HOME}}/.local/share/mise/shims:/usr/bin:/bin" }
+start_calendar_interval = { hour = 5, minute = 15 }
+stdout_path = "~/Library/Logs/time-machine-backup.out.log"
+stderr_path = "~/Library/Logs/time-machine-backup.err.log"
+
 [bootstrap.macos.launchd.agents.woodblock-wallpaper]
 program = "~/.local/share/dotfiles/launch-woodblock-wallpaper"
 run_at_load = true

--- a/files/home/.local/share/dotfiles/run-time-machine-backup.fish
+++ b/files/home/.local/share/dotfiles/run-time-machine-backup.fish
@@ -1,0 +1,43 @@
+#!/usr/bin/env fish
+
+function on_ac_power
+    set -l power_line (/usr/bin/pmset -g batt | /usr/bin/head -n 1)
+    string match -q "*AC Power*" -- $power_line
+end
+
+if not on_ac_power
+    echo "Skipping Time Machine backup while on battery power"
+    exit 0
+end
+
+set -l timeout_seconds 43200
+set -l deadline (math (/bin/date +%s) + $timeout_seconds)
+set -l stop_reason ""
+
+/usr/bin/tmutil startbackup --auto --block &
+set -l backup_pid $last_pid
+/usr/bin/caffeinate -s -t $timeout_seconds -w $backup_pid &
+set -l caffeinate_pid $last_pid
+
+while /bin/kill -0 $backup_pid 2>/dev/null
+    if not on_ac_power
+        set stop_reason "Mac switched to battery power"
+        break
+    end
+    if test (/bin/date +%s) -ge $deadline
+        set stop_reason "12-hour timeout reached"
+        break
+    end
+    /bin/sleep 60
+end
+
+if test -n "$stop_reason"; and /bin/kill -0 $backup_pid 2>/dev/null
+    echo "Stopping Time Machine backup: $stop_reason"
+    /usr/bin/tmutil stopbackup
+end
+
+wait $backup_pid
+set -l backup_status $status
+/bin/kill $caffeinate_pid 2>/dev/null
+wait $caffeinate_pid 2>/dev/null
+exit $backup_status

--- a/files/home/.local/share/dotfiles/run-time-machine-backup.fish
+++ b/files/home/.local/share/dotfiles/run-time-machine-backup.fish
@@ -12,28 +12,19 @@ end
 
 set -l timeout_seconds 43200
 set -l deadline (math (/bin/date +%s) + $timeout_seconds)
-set -l stop_reason ""
 
 /usr/bin/tmutil startbackup --auto --block &
 set -l backup_pid $last_pid
-/usr/bin/caffeinate -s -t $timeout_seconds -w $backup_pid &
+/usr/bin/caffeinate -i -t $timeout_seconds -w $backup_pid &
 set -l caffeinate_pid $last_pid
 
 while /bin/kill -0 $backup_pid 2>/dev/null
-    if not on_ac_power
-        set stop_reason "Mac switched to battery power"
-        break
-    end
     if test (/bin/date +%s) -ge $deadline
-        set stop_reason "12-hour timeout reached"
+        echo "Stopping Time Machine backup: 12-hour timeout reached"
+        /usr/bin/tmutil stopbackup
         break
     end
     /bin/sleep 60
-end
-
-if test -n "$stop_reason"; and /bin/kill -0 $backup_pid 2>/dev/null
-    echo "Stopping Time Machine backup: $stop_reason"
-    /usr/bin/tmutil stopbackup
 end
 
 wait $backup_pid

--- a/lib/dotfiles/steps/mac/configure_time_machine_step.rb
+++ b/lib/dotfiles/steps/mac/configure_time_machine_step.rb
@@ -95,7 +95,7 @@ class Dotfiles::Step::ConfigureTimeMachineStep < Dotfiles::Step
   end
 
   def skip_paths
-    @skip_paths ||= defaults_read("SkipPaths").to_s
+    defaults_read("SkipPaths").to_s
   end
 
   def defaults_bool(value)

--- a/lib/dotfiles/steps/mac/configure_time_machine_wake_step.rb
+++ b/lib/dotfiles/steps/mac/configure_time_machine_wake_step.rb
@@ -1,0 +1,50 @@
+class Dotfiles::Step::ConfigureTimeMachineWakeStep < Dotfiles::Step
+  DESCRIPTION = "Schedules the Mac to wake for its daily Time Machine backup.".freeze
+
+  prepend Dotfiles::Step::Sudoable
+
+  macos_only
+
+  def should_run?
+    configured? && super
+  end
+
+  def run
+    execute(command("pmset", "repeat", "wakeorpoweron", "MTWRFSU", wake_time), sudo: true)
+  end
+
+  def complete?
+    super
+    return true unless configured?
+
+    add_error("Daily Time Machine wake is not scheduled for #{display_wake_time}") unless wake_scheduled?
+    @errors.empty?
+  end
+
+  private
+
+  def configured?
+    !wake_time.empty?
+  end
+
+  def wake_time
+    time_machine_settings.fetch("wake_time", "").to_s
+  end
+
+  def time_machine_settings
+    @time_machine_settings ||= @config.fetch("time_machine_settings", {})
+  end
+
+  def wake_scheduled?
+    output, status = execute(command("pmset", "-g", "sched"), quiet: true)
+    status == 0 && output.downcase.include?("wakepoweron at #{display_wake_time.downcase} every day")
+  end
+
+  def display_wake_time
+    hour, minute = wake_time.split(":").map(&:to_i)
+    period = (hour < 12) ? "AM" : "PM"
+    display_hour = hour % 12
+    display_hour = 12 if display_hour.zero?
+    "#{display_hour}:#{format("%02d", minute)}#{period}"
+  end
+end

--- a/test/dotfiles/steps/configure_time_machine_step_test.rb
+++ b/test/dotfiles/steps/configure_time_machine_step_test.rb
@@ -56,6 +56,18 @@ class ConfigureTimeMachineStepTest < StepTestCase
     assert_incomplete
   end
 
+  def test_complete_after_run_adds_missing_exclusions
+    @fake_system.stub_macos
+    write_time_machine_config
+    stub_time_machine_defaults(skip_paths: [expanded_exclusions.first])
+
+    assert_should_run
+    step.run
+    stub_time_machine_defaults
+
+    assert_complete
+  end
+
   private
 
   def write_time_machine_config(overrides = {})

--- a/test/dotfiles/steps/configure_time_machine_step_test.rb
+++ b/test/dotfiles/steps/configure_time_machine_step_test.rb
@@ -10,7 +10,7 @@ class ConfigureTimeMachineStepTest < StepTestCase
 
     assert_executed(["sudo", "defaults", "write", time_machine_domain, "AutoBackup", "-bool", "true"], quiet: false)
     assert_executed(["sudo", "defaults", "write", time_machine_domain, "AutoBackupInterval", "-int", "86400"], quiet: false)
-    assert_executed(["sudo", "defaults", "write", time_machine_domain, "RequiresACPower", "-bool", "false"], quiet: false)
+    assert_executed(["sudo", "defaults", "write", time_machine_domain, "RequiresACPower", "-bool", "true"], quiet: false)
     assert_executed(["sudo", "tmutil", "addexclusion", "-p", *expanded_exclusions], quiet: false)
   end
 
@@ -49,6 +49,13 @@ class ConfigureTimeMachineStepTest < StepTestCase
     assert_incomplete
   end
 
+  def test_incomplete_when_ac_power_requirement_differs
+    write_time_machine_config
+    stub_time_machine_defaults(overrides: {"RequiresACPower" => "0"})
+
+    assert_incomplete
+  end
+
   def test_incomplete_when_exclusion_missing
     write_time_machine_config
     stub_time_machine_defaults(skip_paths: [expanded_exclusions.first])
@@ -74,7 +81,7 @@ class ConfigureTimeMachineStepTest < StepTestCase
     settings = {
       "auto_backup" => true,
       "auto_backup_interval_seconds" => 86_400,
-      "requires_ac_power" => false,
+      "requires_ac_power" => true,
       "exclusions" => exclusions
     }.merge(overrides)
     write_config("time_machine", "time_machine_settings" => settings)
@@ -84,7 +91,7 @@ class ConfigureTimeMachineStepTest < StepTestCase
     defaults = {
       "AutoBackup" => "1",
       "AutoBackupInterval" => "86400",
-      "RequiresACPower" => "0",
+      "RequiresACPower" => "1",
       "SkipPaths" => defaults_array(skip_paths)
     }.merge(overrides)
 

--- a/test/dotfiles/steps/configure_time_machine_wake_step_test.rb
+++ b/test/dotfiles/steps/configure_time_machine_wake_step_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class ConfigureTimeMachineWakeStepTest < StepTestCase
+  step_class Dotfiles::Step::ConfigureTimeMachineWakeStep
+
+  def test_should_run_when_daily_wake_is_missing
+    write_wake_config
+    stub_schedule("No repeating power events scheduled")
+    @fake_system.stub_macos
+
+    assert_should_run
+  end
+
+  def test_run_schedules_daily_wake
+    write_wake_config
+
+    step.run
+
+    assert_executed(["sudo", "pmset", "repeat", "wakeorpoweron", "MTWRFSU", "05:15:00"], quiet: false)
+  end
+
+  def test_complete_when_daily_wake_matches
+    write_wake_config
+    stub_schedule("wakepoweron at 5:15AM every day")
+
+    assert_complete
+  end
+
+  def test_incomplete_when_daily_wake_differs
+    write_wake_config
+    stub_schedule("wakepoweron at 6:00AM every day")
+
+    assert_incomplete
+  end
+
+  def test_complete_without_wake_time
+    write_config("time_machine_wake", "time_machine_settings" => {})
+
+    assert_complete
+  end
+
+  private
+
+  def write_wake_config
+    write_config("time_machine_wake", "time_machine_settings" => {"wake_time" => "05:15:00"})
+  end
+
+  def stub_schedule(schedule)
+    @fake_system.stub_command(["pmset", "-g", "sched"], "Repeating power events:\n  #{schedule}\n", 0)
+  end
+end

--- a/test/mise_bootstrap_packages_launchd_test.rb
+++ b/test/mise_bootstrap_packages_launchd_test.rb
@@ -12,6 +12,16 @@ class MiseBootstrapPackagesLaunchdTest < Minitest::Test
     assert_includes config.dig("bootstrap", "hooks", "post-packages"), "docker.io"
   end
 
+  def test_declares_daily_time_machine_launch_agent
+    agent = config.dig("bootstrap", "macos", "launchd", "agents", "time-machine-backup")
+
+    assert_equal "~/.local/share/dotfiles/run-time-machine-backup.fish", agent.fetch("program")
+    assert_equal({"PATH" => "{{env.HOME}}/.local/share/mise/shims:/usr/bin:/bin"}, agent.fetch("environment"))
+    assert_equal({"hour" => 5, "minute" => 15}, agent.fetch("start_calendar_interval"))
+    assert_equal "~/Library/Logs/time-machine-backup.out.log", agent.fetch("stdout_path")
+    assert_equal "~/Library/Logs/time-machine-backup.err.log", agent.fetch("stderr_path")
+  end
+
   def test_declares_daily_wallpaper_launch_agent
     agent = config.dig("bootstrap", "macos", "launchd", "agents", "woodblock-wallpaper")
 

--- a/test/trim_mise_config_test.rb
+++ b/test/trim_mise_config_test.rb
@@ -26,6 +26,9 @@ class TrimMiseConfigTest < Minitest::Test
         [bootstrap.macos.launchd.agents.omniwm]
         program = "omniwm"
 
+        [bootstrap.macos.launchd.agents.time-machine-backup]
+        program = "time-machine-backup"
+
         [settings]
         experimental = true
       TOML

--- a/tools/ci/trim_mise_config.rb
+++ b/tools/ci/trim_mise_config.rb
@@ -51,7 +51,7 @@ content = replace_table(content, "[tools]", tool_entries(content)) if ENV.key?("
 if ENV.key?("BREW_CI_PACKAGES") || ENV.key?("DEBIAN_CI_PACKAGES")
   content = replace_table(content, "[bootstrap.packages]", package_entries)
 end
-%w[yknotify woodblock-wallpaper omniwm].each do |agent|
+%w[yknotify woodblock-wallpaper omniwm time-machine-backup].each do |agent|
   content = replace_table(content, "[bootstrap.macos.launchd.agents.#{agent}]", nil)
 end
 File.write(path, content)


### PR DESCRIPTION
## Summary

- schedule a daily `wakeorpoweron` event for 05:15
- install a 05:15 LaunchAgent that starts an automatic-like Time Machine backup
- require AC power when a backup starts
- allow a running backup to continue if the Mac is unplugged
- keep the Mac awake during the backup, with a hard 12-hour stop

## Implementation

The launcher runs blocking `tmutil` separately from `caffeinate`. This matters because `caffeinate -t` is ignored when it directly wraps a utility. Instead, `caffeinate -i -t 43200 -w <tmutil-pid>` watches the blocking process; the launcher stops Time Machine if the watchdog expires while the backup is still running.

The launcher's initial AC check avoids starting on battery, and `RequiresACPower` enables the corresponding native Time Machine policy. Power is deliberately not monitored after startup: a backup that began on AC may finish on battery.

## Validation

- `git diff --check`
- `fish -n files/home/.local/share/dotfiles/run-time-machine-backup.fish`
- parsed managed YAML and TOML configuration
- targeted StandardRB and complexity checks
- `bundle exec rake test` — 416 runs, 1,078 assertions, 0 failures
