### PR TITLE
Prioritize Aube shims in Fish PATH

### DIFF
--- a/files/home/.config/fish/config.fish
+++ b/files/home/.config/fish/config.fish
@@ -63,6 +63,7 @@ if command -v mise >/dev/null 2>&1
   mise hook-env -s fish | source
   if command -q aube
     aube activate fish | source
+    set -gx PATH $AUBE_SHIM_DIR (string match -v -- $AUBE_SHIM_DIR $PATH)
   end
 
   function __mise_refresh_on_cd --on-variable PWD


### PR DESCRIPTION
## Summary

- move the Aube shim directory to the front of `PATH` after activation
- remove any inherited duplicate so child processes resolve npm-compatible commands consistently

## Validation

- `fish --no-execute files/home/.config/fish/config.fish`
- sourced the managed Fish config in a clean Fish process and verified `npx` resolves to `$AUBE_SHIM_DIR/npx`
- `mise run test` (416 runs, 1,078 assertions)

## Notes

- `mise run lint` is currently polluted by pre-existing untracked `.claude/worktrees/*/vendor` trees; the failures are entirely within those untracked dependency copies.