### PR TITLE
Apply package safety defaults in Bash

### DIFF
--- a/files/home/.bashrc
+++ b/files/home/.bashrc
@@ -56,6 +56,11 @@ if command -v mise >/dev/null 2>&1; then
   export PATH
 fi
 
+if [[ -f "$HOME/.config/bash/safety.bash" ]]; then
+  # shellcheck source=/dev/null
+  source "$HOME/.config/bash/safety.bash"
+fi
+
 _apply_mise_network_status() {
   if [[ -f /tmp/mise_network_status ]]; then
     if [[ "$(</tmp/mise_network_status)" == "offline" ]]; then

--- a/files/home/.config/bash/safety.bash
+++ b/files/home/.config/bash/safety.bash
@@ -1,0 +1,46 @@
+# Safety defaults for interactive and agent-launched Bash shells.
+
+export MISE_SHELL=bash
+
+if command -v mise >/dev/null 2>&1; then
+  eval "$(mise hook-env -s bash)"
+fi
+
+_path_force_prepend() {
+  local dir="$1" entry remainder=""
+  local IFS=:
+
+  for entry in $PATH; do
+    if [[ "$entry" != "$dir" ]]; then
+      remainder="${remainder:+$remainder:}$entry"
+    fi
+  done
+
+  export PATH="$dir${remainder:+:$remainder}"
+}
+
+if command -v aube >/dev/null 2>&1; then
+  eval "$(aube activate bash)"
+  _path_force_prepend "$AUBE_SHIM_DIR"
+fi
+unset -f _path_force_prepend
+
+_socket_firewall_enabled() {
+  [[ -z "${SOCKET_FIREWALL_DISABLE:-}" || "$SOCKET_FIREWALL_DISABLE" == "0" ]] && command -v sfw >/dev/null 2>&1
+}
+
+_socket_firewall_run() {
+  local tool="$1"
+  shift
+
+  if _socket_firewall_enabled; then
+    SOCKET_FIREWALL_DISABLE=1 command sfw "$tool" "$@"
+  else
+    command "$tool" "$@"
+  fi
+}
+
+pip() { _socket_firewall_run pip "$@"; }
+pip3() { _socket_firewall_run pip3 "$@"; }
+uv() { _socket_firewall_run uv "$@"; }
+cargo() { _socket_firewall_run cargo "$@"; }

--- a/files/home/.config/mise/config.toml
+++ b/files/home/.config/mise/config.toml
@@ -66,6 +66,7 @@ fetch_remote_versions_timeout = "5s"
 
 [env]
 AUBE_SECURITY_SCANNER = "{{env.HOME}}/.config/aube/socket-security-scanner.mjs"
+BASH_ENV = "{{env.HOME}}/.config/bash/safety.bash"
 CARGO_HTTP_TIMEOUT = "5"
 GO_GET_TIMEOUT = "5s"
 

--- a/test/bash/safety_environment_test.rb
+++ b/test/bash/safety_environment_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+require "open3"
+require "tmpdir"
+
+# standard:disable Dotfiles/BanFileSystemClasses
+class SafetyEnvironmentTest < Minitest::Test
+  SCRIPT = File.expand_path("../../files/home/.config/bash/safety.bash", __dir__)
+
+  def setup
+    skip "Bash is not installed" unless system("bash", "--version", out: File::NULL)
+  end
+
+  def test_applies_safety_defaults_to_noninteractive_bash
+    Dir.mktmpdir("bash-safety") do |tmpdir|
+      bin = File.join(tmpdir, "bin")
+      shims = File.join(tmpdir, "aube-shims")
+      FileUtils.mkdir_p(bin)
+      FileUtils.mkdir_p(shims)
+      write_executable(bin, "mise", <<~SH)
+        #!/bin/sh
+        echo 'export MISE_SAFETY_ACTIVE=1'
+      SH
+      write_executable(bin, "aube", <<~SH)
+        #!/bin/sh
+        echo 'export AUBE_SHIM_DIR=#{shims}'
+      SH
+      write_executable(bin, "sfw", <<~SH)
+        #!/bin/sh
+        printf 'sfw:%s\\n' "$*"
+      SH
+      write_executable(shims, "npx", "#!/bin/sh\n")
+
+      path = [bin, "/usr/bin", "/bin", shims].join(":")
+      command = "printf '%s\\n' \"$MISE_SAFETY_ACTIVE\" \"$MISE_SHELL\" \"$(command -v npx)\"; cargo install demo"
+      output, status = Open3.capture2e({"BASH_ENV" => SCRIPT, "PATH" => path}, "bash", "--noprofile", "--norc", "-c", command)
+
+      assert status.success?, output
+      assert_equal ["1", "bash", File.join(shims, "npx"), "sfw:cargo install demo"], output.lines.map(&:chomp)
+    end
+  end
+
+  private
+
+  def write_executable(directory, name, contents)
+    path = File.join(directory, name)
+    File.write(path, contents)
+    FileUtils.chmod("u+x", path)
+  end
+end
+# standard:enable Dotfiles/BanFileSystemClasses

--- a/test/mise_bootstrap_dotfiles_defaults_test.rb
+++ b/test/mise_bootstrap_dotfiles_defaults_test.rb
@@ -12,6 +12,10 @@ class MiseBootstrapDotfilesDefaultsTest < Minitest::Test
     assert_equal "copy", dotfiles.fetch("~/.local/share/yknotify/yknotify.sh").fetch("mode")
   end
 
+  def test_exports_noninteractive_bash_safety_setup
+    assert_equal "{{env.HOME}}/.config/bash/safety.bash", config.fetch("env").fetch("BASH_ENV")
+  end
+
   def test_declares_existing_fixed_macos_defaults
     defaults = config.dig("bootstrap", "macos", "defaults")
 


### PR DESCRIPTION
## Summary

- export `BASH_ENV` through mise so noninteractive Bash processes—including agent command runners—load safety defaults
- refresh mise for each Bash process based on its actual working directory
- activate Aube and force its shims ahead of npm/npx binaries already inherited through `PATH`
- route pip, pip3, uv, and cargo through Socket Firewall, matching Fish behavior
- share the same safety setup with interactive Bash through `.bashrc`

## Why

Fish currently applies package-manager safety behavior through startup functions and Aube activation, but those functions do not cross the process boundary when an agent launches Bash. Interactive Bash also activates mise but does not activate Aube or define the Socket Firewall wrappers. As a result, npm/npx and the Python/Rust package managers can resolve differently depending on which shell executes a command.

`AUBE_SECURITY_SCANNER` was already shell-independent because mise exports it globally; this change preserves that behavior. Fish-only aliases, prompts, editor settings, and other UX helpers remain shell-specific.

## Validation

- regression test launches noninteractive Bash through `BASH_ENV` and verifies mise refresh, Bash shell identity, Aube npx priority, and Socket Firewall cargo routing
- `bundle exec rake test` (418 runs, 1,081 assertions)
- targeted StandardRB, ShellCheck, Bash syntax, and diff checks pass

## Local lint note

The repository-wide lint task is polluted by pre-existing untracked `.claude/worktrees/*/vendor` trees. Targeted lint for all changed Ruby and Bash files passes; CI runs in a clean checkout.