### PR TITLE
Contain Claude worktree state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ mise.local.lock
 logs/
 .rubocop_cache/
 .bundle/
+.claude/settings.local.json
+.claude/worktrees/
 !files/home/.bundle/
 !files/home/.bundle/config
 vendor/bundle/

--- a/.mise.toml
+++ b/.mise.toml
@@ -23,12 +23,12 @@ run = "mise deps"
 
 [tasks."lint:standard"]
 description = "Run standardrb"
-sources = ["**/*.rb", "!tmp/**", "!vendor/**", "!.pi-subagents/**", ".standard.yml"]
+sources = ["**/*.rb", "!tmp/**", "!vendor/**", "!.claude/worktrees/**", "!.pi-subagents/**", ".standard.yml"]
 run = "bundle exec standardrb"
 
 [tasks."lint:complexity"]
 description = "Run Ruby complexity checks"
-sources = ["**/*.rb", "!tmp/**", "!vendor/**", "!.pi-subagents/**", ".rubocop-custom.yml"]
+sources = ["**/*.rb", "!tmp/**", "!vendor/**", "!.claude/worktrees/**", "!.pi-subagents/**", ".rubocop-custom.yml"]
 run = "bundle exec rubocop --config .rubocop-custom.yml --only Metrics/PerceivedComplexity"
 
 [tasks."lint:human-only"]
@@ -42,17 +42,17 @@ run = "gitleaks dir --redact=75 --no-banner --no-color --max-target-megabytes 5 
 
 [tasks."lint:dead-code"]
 description = "Check for dead Ruby methods"
-sources = ["**/*.rb", "**/*.rake", "!tmp/**", "!vendor/**", "!.pi-subagents/**", "bin/*", "Rakefile", ".debride-whitelist", "files/home/.claude/skills/dev-env-setup/scripts/check_dead_code.rb"]
+sources = ["**/*.rb", "**/*.rake", "!tmp/**", "!vendor/**", "!.claude/worktrees/**", "!.pi-subagents/**", "bin/*", "Rakefile", ".debride-whitelist", "files/home/.claude/skills/dev-env-setup/scripts/check_dead_code.rb"]
 run = "ruby files/home/.claude/skills/dev-env-setup/scripts/check_dead_code.rb"
 
 [tasks."lint:flog"]
 description = "Run flog complexity checks"
-sources = ["**/*.rb", "!tmp/**", "!vendor/**", "!.pi-subagents/**", "Rakefile"]
+sources = ["**/*.rb", "!tmp/**", "!vendor/**", "!.claude/worktrees/**", "!.pi-subagents/**", "Rakefile"]
 run = "bundle exec rake flog"
 
 [tasks."lint:flay"]
 description = "Run flay duplication checks"
-sources = ["**/*.rb", "!tmp/**", "!vendor/**", "!.pi-subagents/**", "Rakefile"]
+sources = ["**/*.rb", "!tmp/**", "!vendor/**", "!.claude/worktrees/**", "!.pi-subagents/**", "Rakefile"]
 run = "bundle exec rake flay"
 
 [tasks."lint:skills"]
@@ -66,7 +66,7 @@ depends = ["lint:standard", "lint:complexity", "lint:human-only", "lint:secrets"
 
 [tasks.test]
 description = "Run the test suite"
-sources = ["**/*.rb", "!tmp/**", "!vendor/**", "!.pi-subagents/**", "test/**/*", "lib/**/*"]
+sources = ["**/*.rb", "!tmp/**", "!vendor/**", "!.claude/worktrees/**", "!.pi-subagents/**", "test/**/*", "lib/**/*"]
 run = "bundle exec rake test"
 
 [tasks.dev]

--- a/.rubocop-custom.yml
+++ b/.rubocop-custom.yml
@@ -2,6 +2,7 @@ AllCops:
   NewCops: disable
   Exclude:
     - '.bundle/**/*'
+    - '.claude/worktrees/**/*'
     - 'vendor/**/*'
     - 'tmp/**/*'
 

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,5 +1,6 @@
 ignore:
   - '.bundle/**/*'
+  - '.claude/worktrees/**/*'
   - '.ruby-lsp/**/*'
 
 extend_config:

--- a/files/home/.claude/settings.json
+++ b/files/home/.claude/settings.json
@@ -2,5 +2,6 @@
   "model": "opus",
   "effortLevel": "high",
   "autoMemoryEnabled": false,
+  "cleanupPeriodDays": 1,
   "skipDangerousModePermissionPrompt": true
 }


### PR DESCRIPTION
## Summary

- ignore Claude's machine-local settings and retained repo-local worktrees
- exclude retained worktrees from Ruby lint/test task discovery
- ask Claude Code to clean eligible worktrees after one day

## Diagnosis

The two existing `.claude/worktrees/agent-*` directories were created by Claude subagents launched from this dotfiles repository, not by an unrelated Claude process with another working directory. Both belong to Claude session `1b406af0-df99-4979-a218-04ecac3ff1d2`, whose recorded cwd is this checkout.

Claude intentionally retained the clean, pushed worktrees after those subagents finished. One also has a stale Claude lock naming a dead process. Because the worktrees include vendored gems, repository-wide Ruby tools discovered thousands of irrelevant files and could appear to hang.

This PR contains the local state without deleting the existing worktrees. Claude's normal cleanup can remove eligible retained worktrees on the shorter configured schedule.

## Validation

- `git check-ignore -v .claude/settings.local.json .claude/worktrees/agent-a41f83cb9b7f8dd89/vendor/bundle/ruby.rb`
- `bundle exec standardrb`
- `bundle exec rubocop --cache false --config .rubocop-custom.yml --only Metrics/PerceivedComplexity`
- `mise run lint`
- `mise run test` (418 runs, 1,081 assertions)
- commit hooks passed
