### PR TITLE
Add mlx command for trying latest mise tools

### DIFF
--- a/files/home/.config/fish/functions/mlx.fish
+++ b/files/home/.config/fish/functions/mlx.fish
@@ -1,0 +1,28 @@
+function mlx --description "Run the latest version of a mise-managed command"
+  if test (count $argv) -eq 0
+    echo "Usage: mlx COMMAND [ARGUMENTS...]" >&2
+    return 2
+  end
+
+  set -l bin $argv[1]
+  set -e argv[1]
+  set -l tool (mise which "$bin" --plugin); or return
+  set -lx MISE_MINIMUM_RELEASE_AGE 0s
+
+  if string match -q "npm:*" "$tool"
+    set -l package (string replace "npm:" "" "$tool")
+    set -l exclusion "$package"
+
+    if string match -q "@*/*" "$package"
+      set exclusion (string replace -r '^(@[^/]+)/.*$' '$1/*' "$package")
+    end
+
+    if set -q AUBE_MINIMUM_RELEASE_AGE_EXCLUDE
+      set exclusion "$AUBE_MINIMUM_RELEASE_AGE_EXCLUDE,$exclusion"
+    end
+
+    set -fx AUBE_MINIMUM_RELEASE_AGE_EXCLUDE "$exclusion"
+  end
+
+  mise x "$tool"@latest -- "$bin" $argv
+end

--- a/test/fish/mlx_test.rb
+++ b/test/fish/mlx_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+require "open3"
+require "shellwords"
+require "tmpdir"
+
+# standard:disable Dotfiles/BanFileSystemClasses
+class MlxTest < Minitest::Test
+  FUNCTION_PATH = File.expand_path("../../files/home/.config/fish/functions/mlx.fish", __dir__)
+
+  def setup
+    skip "Fish is not installed" unless system("fish", "--version", out: File::NULL)
+  end
+
+  def test_runs_latest_scoped_npm_tool_with_release_age_exclusion
+    output = run_mlx("npm:@earendil-works/pi-coding-agent", "mlx pi --model astra", "existing")
+
+    assert_includes output, "age=0s"
+    assert_includes output, "exclude=existing,@earendil-works/*"
+    assert_includes output, "args=<x><npm:@earendil-works/pi-coding-agent@latest><--><pi><--model><astra>"
+  end
+
+  def test_runs_latest_non_npm_tool_without_aube_exclusion
+    output = run_mlx("github:cli/cli", "mlx gh --version")
+
+    assert_includes output, "age=0s"
+    assert_includes output, "exclude=<unset>"
+    assert_includes output, "args=<x><github:cli/cli@latest><--><gh><--version>"
+  end
+
+  def test_requires_a_command
+    output, status = Open3.capture2e("fish", "--no-config", "--command", "source #{Shellwords.escape(FUNCTION_PATH)}; mlx")
+
+    refute status.success?
+    assert_equal "Usage: mlx COMMAND [ARGUMENTS...]\n", output
+  end
+
+  private
+
+  def run_mlx(tool, command, exclusion = nil)
+    Dir.mktmpdir("mlx-test") do |dir|
+      mise = File.join(dir, "mise")
+      File.write(mise, fake_mise)
+      FileUtils.chmod("+x", mise)
+      env = {
+        "PATH" => "#{dir}:#{ENV.fetch("PATH")}",
+        "FAKE_MISE_TOOL" => tool,
+        "AUBE_MINIMUM_RELEASE_AGE_EXCLUDE" => exclusion
+      }
+      output, status = Open3.capture2e(env, "fish", "--no-config", "--command", "source #{Shellwords.escape(FUNCTION_PATH)}; #{command}")
+      assert status.success?, output
+      output
+    end
+  end
+
+  def fake_mise
+    <<~SH
+      #!/bin/sh
+      if [ "$1" = "which" ]; then
+        printf '%s\n' "$FAKE_MISE_TOOL"
+        exit
+      fi
+      printf 'age=%s\n' "${MISE_MINIMUM_RELEASE_AGE-<unset>}"
+      printf 'exclude=%s\n' "${AUBE_MINIMUM_RELEASE_AGE_EXCLUDE-<unset>}"
+      printf 'args='; printf '<%s>' "$@"; printf '\n'
+    SH
+  end
+end
+# standard:enable Dotfiles/BanFileSystemClasses


### PR DESCRIPTION
## Summary

- add `mlx` to run the latest release of any mise-managed command without changing its pin
- bypass mise's top-level release-age filter only for the `mlx` invocation
- scope aube's npm exception to the selected package or publisher scope while retaining existing exclusions
- cover command forwarding, npm exclusions, non-npm tools, and missing arguments

## Validation

- `fish -n files/home/.config/fish/functions/mlx.fish`
- `bundle exec ruby -Itest test/fish/mlx_test.rb`
- `env -u BASH_ENV bundle exec rake test` (421 runs, 1097 assertions)
- live check: `mlx pi --version` returned `0.85.1`