### PR TITLE
Fix recursive Bash safety startup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,6 @@ jobs:
         ruby-version: 'ruby'
         bundler-cache: true
 
-    - name: Run tests
+    - name: Run tests with managed Bash startup
+      timeout-minutes: 5
       run: bundle exec rake test

--- a/Rakefile
+++ b/Rakefile
@@ -4,13 +4,21 @@ require "standard/rake"
 
 FLOG_THRESHOLD = (ENV["FLOG_THRESHOLD"] || 25).to_i
 FLAY_THRESHOLD = (ENV["FLAY_THRESHOLD"] || 10).to_i
+ENV["BASH_ENV"] = File.expand_path("files/home/.config/bash/safety.bash", __dir__)
 
 task default: [:test, :standard, :flog, :flay]
+
+Rake::TestTask.new("test:bash_safety") do |t|
+  t.libs << "test"
+  t.test_files = FileList["test/bash/safety_environment_test.rb"]
+end
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.test_files = FileList["test/**/*_test.rb"]
 end
+# Run the bounded startup check before the suite can launch other Bash processes.
+Rake::Task[:test].enhance(["test:bash_safety"])
 
 desc "Run flog"
 task :flog do

--- a/files/home/.config/bash/safety.bash
+++ b/files/home/.config/bash/safety.bash
@@ -2,8 +2,9 @@
 
 export MISE_SHELL=bash
 
+# Bash-backed startup tools must not recursively reload this file.
 if command -v mise >/dev/null 2>&1; then
-  eval "$(mise hook-env -s bash)"
+  eval "$(BASH_ENV='' mise hook-env -s bash)"
 fi
 
 _path_force_prepend() {
@@ -20,7 +21,7 @@ _path_force_prepend() {
 }
 
 if command -v aube >/dev/null 2>&1; then
-  eval "$(aube activate bash)"
+  eval "$(BASH_ENV='' aube activate bash)"
   _path_force_prepend "$AUBE_SHIM_DIR"
 fi
 unset -f _path_force_prepend

--- a/test/bash/safety_environment_test.rb
+++ b/test/bash/safety_environment_test.rb
@@ -7,39 +7,71 @@ class SafetyEnvironmentTest < Minitest::Test
   SCRIPT = File.expand_path("../../files/home/.config/bash/safety.bash", __dir__)
 
   def setup
-    skip "Bash is not installed" unless system("bash", "--version", out: File::NULL)
+    bash_installed = ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).any? do |directory|
+      File.executable?(File.join(directory, "bash"))
+    end
+    skip "Bash is not installed" unless bash_installed
   end
 
-  def test_applies_safety_defaults_to_noninteractive_bash
+  def test_applies_safety_defaults_without_recursive_bash_startup
     Dir.mktmpdir("bash-safety") do |tmpdir|
       bin = File.join(tmpdir, "bin")
       shims = File.join(tmpdir, "aube-shims")
-      FileUtils.mkdir_p(bin)
-      FileUtils.mkdir_p(shims)
+      loads = File.join(tmpdir, "bash-env-loads")
+      startup_env = File.join(tmpdir, "startup-env")
+      bash_env = File.join(tmpdir, "bash-env")
+      FileUtils.mkdir_p([bin, shims])
+      write_bounded_bash_env(bash_env)
       write_executable(bin, "mise", <<~SH)
-        #!/bin/sh
+        #!/bin/bash
+        [[ -z "${BASH_ENV:-}" ]] && state=unset || state=set
+        printf 'mise:%s\\n' "$state" >> "$STARTUP_ENV_LOG"
         echo 'export MISE_SAFETY_ACTIVE=1'
       SH
       write_executable(bin, "aube", <<~SH)
-        #!/bin/sh
-        echo 'export AUBE_SHIM_DIR=#{shims}'
+        #!/bin/bash
+        [[ -z "${BASH_ENV:-}" ]] && state=unset || state=set
+        printf 'aube:%s\\n' "$state" >> "$STARTUP_ENV_LOG"
+        printf 'export AUBE_SHIM_DIR=%q\\n' "$AUBE_TEST_SHIM_DIR"
       SH
-      write_executable(bin, "sfw", <<~SH)
-        #!/bin/sh
-        printf 'sfw:%s\\n' "$*"
-      SH
+      write_executable(bin, "sfw", "#!/bin/sh\nprintf 'sfw:%s\\n' \"$*\"\n")
       write_executable(shims, "npx", "#!/bin/sh\n")
 
-      path = [bin, "/usr/bin", "/bin", shims].join(":")
+      env = {
+        "BASH_ENV" => bash_env,
+        "BASH_SAFETY_SCRIPT" => SCRIPT,
+        "BASH_SAFETY_LOADS" => loads,
+        "STARTUP_ENV_LOG" => startup_env,
+        "AUBE_TEST_SHIM_DIR" => shims,
+        "SOCKET_FIREWALL_DISABLE" => nil,
+        "PATH" => [bin, "/usr/bin", "/bin", shims].join(":")
+      }
       command = "printf '%s\\n' \"$MISE_SAFETY_ACTIVE\" \"$MISE_SHELL\" \"$(command -v npx)\"; cargo install demo"
-      output, status = Open3.capture2e({"BASH_ENV" => SCRIPT, "PATH" => path}, "bash", "--noprofile", "--norc", "-c", command)
+      output, status = Open3.capture2e(env, "bash", "--noprofile", "--norc", "-c", command)
 
       assert status.success?, output
+      assert_equal "1", File.read(loads).chomp, "BASH_ENV loaded recursively"
+      assert_equal ["mise:unset", "aube:unset"], File.readlines(startup_env, chomp: true)
       assert_equal ["1", "bash", File.join(shims, "npx"), "sfw:cargo install demo"], output.lines.map(&:chomp)
     end
   end
 
   private
+
+  def write_bounded_bash_env(path)
+    File.write(path, <<~'SH')
+      loads=0
+      if [[ -f "$BASH_SAFETY_LOADS" ]]; then
+        read -r loads < "$BASH_SAFETY_LOADS"
+      fi
+      ((loads += 1))
+      printf '%s\n' "$loads" > "$BASH_SAFETY_LOADS"
+      if ((loads > 4)); then
+        exit 90
+      fi
+      source "$BASH_SAFETY_SCRIPT"
+    SH
+  end
 
   def write_executable(directory, name, contents)
     path = File.join(directory, name)

--- a/test/post_dotfiles_hook_test.rb
+++ b/test/post_dotfiles_hook_test.rb
@@ -16,7 +16,7 @@ class PostDotfilesHookTest < Minitest::Test
       FileUtils.mkdir_p([File.dirname(plist), bin])
       File.write(plist, "legacy")
       write_command(bin, "uname", "echo Darwin")
-      write_command(bin, "mise", 'echo "$*" >> "$MISE_TRACE"')
+      write_command(bin, "mise", '[ "$*" = "hook-env -s bash" ] || echo "$*" >> "$MISE_TRACE"')
       write_command(bin, "launchctl", 'echo "$*" >> "$LAUNCHCTL_TRACE"')
 
       _stdout, stderr, status = Open3.capture3(


### PR DESCRIPTION
## Summary
- prevent Bash-backed `mise` and `aube` commands from recursively loading `BASH_ENV`
- add a bounded regression test that fails safely instead of spawning unbounded processes
- run that regression before the full suite, then exercise all tests with the managed Bash startup file
- cap the unit-test CI step at five minutes

## Why
PR #635 intentionally applies mise, Aube, and Socket Firewall safety to every Bash process. When `mise` or `aube` resolves to a Bash script, Bash loads the same startup file before the command body and recursively starts another process. This preserves #635's behavior while suppressing `BASH_ENV` only for those two startup commands.

## Validation
- `bundle exec rake test` (416 total runs including the bounded preflight)
- `mise run lint`
- `shellcheck -s bash files/home/.config/bash/safety.bash`
- original bootstrap reproduction completes normally with peak matching process count 1
