### PR TITLE
Update Pi scoped models

### DIFF
--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -25,9 +25,9 @@
     "path": "/System/Library/Sounds/Glass.aiff"
   },
   "enabledModels": [
+    "openai-codex/gpt-6-astra:low",
     "openai-codex/gpt-5.6-sol:medium",
-    "openai-codex/gpt-5.6-terra:xhigh",
-    "fireworks/accounts/fireworks/routers/glm-5p2-fast-us"
+    "openai-codex/gpt-5.6-luna:xhigh"
   ],
   "subagents": {
     "agentOverrides": {


### PR DESCRIPTION
## Summary
- make `openai-codex/gpt-6-astra:low` the first scoped model
- keep `openai-codex/gpt-5.6-sol:medium` second
- replace the remaining scoped models with `openai-codex/gpt-5.6-luna:xhigh`

## Validation
- parsed `files/home/.pi/agent/settings.json` with `jq`
- full pre-commit lint and test suite passed
