### PR TITLE
Manage Python with mise and stop installing Cursor

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -16,7 +16,6 @@ debian_desktop_apps:
     key_url: https://dl.google.com/linux/linux_signing_key.pub
 brew_casks:
   - 1password
-  - cursor
   - discord
   - dropbox
   - ghostty

--- a/config/dependency-updater.yml
+++ b/config/dependency-updater.yml
@@ -5,7 +5,6 @@ minimum_release_age_days: 3
 # downgrades self-updating applications to these versions.
 observed_casks:
   1password: "8.12.33"
-  cursor: "3.16.17,6b2afae0257df2bb5e1835f15165dc2f0de056b2"
   discord: "0.0.408"
   dropbox: "264.4.3421"
   ghostty: "1.3.1"

--- a/files/home/.config/mise/config.toml
+++ b/files/home/.config/mise/config.toml
@@ -1,6 +1,7 @@
 # Managed by dotfiles. This file is the source of truth for machine-wide mise tools.
 [tools]
 ruby = "4.0.6"
+python = "3.14.7"
 node = "26.8.1"
 "github:aubepkg/aube" = "2.2.4"
 go = "1.27.0"

--- a/files/home/.config/mise/mise.lock
+++ b/files/home/.config/mise/mise.lock
@@ -440,6 +440,20 @@ checksum = "sha256:563eb51c9a20b16a3625464ed745c675ed9750381f2126722696a0d7cac1d
 url = "https://github.com/apple/pkl/releases/download/0.32.1/pkl-macos-aarch64"
 url_api = "https://api.github.com/repos/apple/pkl/releases/assets/487426570"
 
+[[tools.python]]
+version = "3.14.7"
+backend = "core:python"
+
+[tools.python."platforms.linux-x64"]
+checksum = "sha256:3959f92825141e04adf44982d3a83ee57af0877e893b0796e04c1468749d9b04"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260901/cpython-3.14.7+20260901-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+provenance = "github-attestations"
+
+[tools.python."platforms.macos-arm64"]
+checksum = "sha256:4632cb1a6edad9e73d3c81b6d2e69131637d995173e3e85005df14102b0592ba"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260901/cpython-3.14.7+20260901-aarch64-apple-darwin-install_only_stripped.tar.gz"
+provenance = "github-attestations"
+
 [[tools.ripgrep]]
 version = "15.2.0"
 backend = "aqua:BurntSushi/ripgrep"


### PR DESCRIPTION
## Summary
- Pin machine-wide Python to 3.14.7 in the managed mise config, with checksummed Linux x64 and macOS arm64 lock entries.
- Remove Cursor from managed Homebrew casks and its update baseline so convergence does not reinstall it.
- Leave mise-managed tmux intact. Obsidian and Neovim are not explicitly managed here. Homebrew Python dependencies are intentionally retained on the host; this PR does not force-remove them or change live configuration.

## Validation
- `bundle exec rake test`: 415 runs, 1099 assertions, no failures/errors/skips.
- Pre-commit checks passed.
- `git diff --check` passed.
- Native lock provenance will be checked by CI.