### PR TITLE
Configure global Pi model defaults by subagent role

### DIFF
--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -1,8 +1,8 @@
 {
   "lastChangelogVersion": "0.80.9",
   "defaultProvider": "openai-codex",
-  "defaultModel": "gpt-5.6-sol",
-  "defaultThinkingLevel": "medium",
+  "defaultModel": "gpt-6-astra",
+  "defaultThinkingLevel": "low",
   "hideThinkingBlock": false,
   "packages": [
     "npm:pi-mcp-adapter@2.32.1",
@@ -31,17 +31,33 @@
   ],
   "subagents": {
     "agentOverrides": {
+      "delegate": {
+        "model": "openai-codex/gpt-6-astra",
+        "thinking": "low"
+      },
       "reviewer": {
+        "model": "openai-codex/gpt-6-astra",
         "thinking": "xhigh"
       },
       "oracle": {
+        "model": "openai-codex/gpt-6-astra",
         "thinking": "xhigh"
       },
       "advisor": {
+        "model": "openai-codex/gpt-6-astra",
         "thinking": "xhigh"
       },
+      "scout": {
+        "model": "openai-codex/gpt-5.6-sol",
+        "thinking": "low"
+      },
       "worker": {
-        "thinking": "medium"
+        "model": "openai-codex/gpt-6-astra",
+        "thinking": "low"
+      },
+      "researcher": {
+        "model": "openai-codex/gpt-5.6-luna",
+        "thinking": "max"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Global default: Astra / low
- Delegate and worker: Astra / low
- Oracle, advisor, reviewer: Astra / xhigh
- Scout: Sol 5.6 / low
- Researcher: Luna 5.6 / max

Replaces #649, which accidentally included unrelated commits. Created in an isolated worktree from origin/main; exactly one commit and one settings file changed.

## Validation
- JSON parsing and git diff --check passed
- Clean-worktree test run blocked by missing bundled gems; CI will validate. Previous checkout tests passed, but were on the wrong base.