### PR TITLE
Install Word Count from GitHub release

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -63,3 +63,7 @@ vscode_extension_sources:
     github: nateberkopec/vscodevim
     tag: core-v1.32.4
     asset: vscodevim-core-1.32.4.vsix
+  nateberkopec.wordcount:
+    github: nateberkopec/vscode-wordcount
+    tag: v0.1.0-nate.1
+    asset: wordcount.vsix


### PR DESCRIPTION
## Summary

- configure `nateberkopec.wordcount` as a GitHub release-backed VS Code extension
- install the unpublished extension from its `v0.1.0-nate.1` VSIX asset instead of querying the Marketplace

## Validation

- `bundle exec rake test`
- `mise run lint`