### PR TITLE
Run Pi with machine-wide Node

### DIFF
--- a/files/home/.config/fish/config.fish
+++ b/files/home/.config/fish/config.fish
@@ -45,6 +45,10 @@ set -Ux HOMEBREW_NO_REQUIRE_TAP_TRUST 1
 # Suppress pi's startup update/package-update notices for normal agent sessions.
 # Leave package-management subcommands online so `pi update` still works.
 function pi
+  # Keep Pi on the machine-wide Node instead of a project's pinned version.
+  set -l node_root (mise -C "$HOME" where node); or return
+  set -lx PATH "$node_root/bin" $PATH
+
   if test (count $argv) -gt 0
     switch $argv[1]
       case install remove uninstall update list


### PR DESCRIPTION
## Summary

- resolve Node from the machine-wide mise context before launching Pi
- prepend that concrete Node installation only within the Fish `pi` function
- preserve project-local Node pins for all other commands and retain Pi's online package-management exceptions

## Why

The Aube-generated Pi shim launches an unqualified `node`. In projects with an older Node pin, such as `global-web` on Node 20.18.0, Pi 0.84.4 fails because it requires Node >=22.19.0.

## Validation

- `fish -n files/home/.config/fish/config.fish`
- hostile-runtime check from `global-web`: outer `node --version` returned `v20.18.0`, while wrapped `pi --version` returned `0.84.4`
- `mise run lint`

## Existing test issue

`bundle exec rake test` reached 445 tests but the pre-existing `DotfUpdateNoticeTest#test_greeting_checks_for_changes_in_the_background` missed its two-second asynchronous deadline. The changed function body is inert during that test and the failure reproduced in isolated reruns.