### PR TITLE
Fix Fish greeting background checks resolving through mise shims

### DIFF
--- a/files/home/.config/fish/config.fish
+++ b/files/home/.config/fish/config.fish
@@ -22,7 +22,8 @@ function fish_greeting
         end
     end
 
-    command fish --no-config --command 'source "$__fish_config_dir/functions/__dotf_refresh_update_notice.fish"; __dotf_refresh_update_notice' >/dev/null 2>&1 &
+    set -l fish_bin (status fish-path)
+    command "$fish_bin" --no-config --command 'source "$__fish_config_dir/functions/__dotf_refresh_update_notice.fish"; __dotf_refresh_update_notice' >/dev/null 2>&1 &
     disown $last_pid 2>/dev/null
     return 0
 end

--- a/test/fish/dotf_update_notice_test.rb
+++ b/test/fish/dotf_update_notice_test.rb
@@ -32,10 +32,14 @@ class DotfUpdateNoticeTest < Minitest::Test
       FileUtils.mkdir_p(function_dir)
       File.write(File.join(state_dir, "last-run-sha"), "#{initial_sha}\n")
       FileUtils.cp(FUNCTION_PATH, function_dir)
+      shim_dir = File.join(tmpdir, "shims")
+      FileUtils.mkdir_p(shim_dir)
+      File.write(File.join(shim_dir, "fish"), "#!/bin/sh\nexit 99\n")
+      FileUtils.chmod(0o755, File.join(shim_dir, "fish"))
 
       output, status = Open3.capture2e(
         GIT_ENV.merge("DOTFILES_DIR" => checkout, "HOME" => home, "XDG_STATE_HOME" => state_home),
-        "fish", "--no-config", "--command", "source #{Shellwords.escape(CONFIG_PATH)}; fish_greeting"
+        "fish", "--no-config", "--command", "source #{Shellwords.escape(CONFIG_PATH)}; set -gx PATH #{Shellwords.escape(shim_dir)} $PATH; fish_greeting"
       )
 
       assert status.success?, output


### PR DESCRIPTION
## Root cause
Sourcing config.fish activates mise and changes PATH. The greeting then looked up fish again through PATH, resolving a mise shim rather than the already-running Fish executable. Under the test temporary HOME, mise rejects the untrusted project configuration, so the suppressed background command never creates needs-run.

## Fix
- Launch the child using status fish-path, avoiding another PATH/version-manager lookup.
- Strengthen the existing end-to-end greeting test by prepending a failing fish shim after config sourcing. The real Git fetch must still create the marker within the existing deadline.
- Keep the background/disown behavior and two-second test deadline unchanged.

## Validation
- Original targeted test reproduced the missing marker.
- Updated regression fails against the original config and passes against the fix (4 tests, 66 assertions).
- Full pre-commit hooks passed without skips, including 441 tests / 1196 assertions and all lints.

Separate from #671; no Pi package changes or machine convergence.