### PR TITLE
Use Sol for implementation and research subagents

### DIFF
--- a/files/home/.pi/agent/settings.json
+++ b/files/home/.pi/agent/settings.json
@@ -33,8 +33,8 @@
   "subagents": {
     "agentOverrides": {
       "delegate": {
-        "model": "openai-codex/gpt-6-astra",
-        "thinking": "low"
+        "model": "openai-codex/gpt-5.6-sol",
+        "thinking": "medium"
       },
       "reviewer": {
         "model": "openai-codex/gpt-6-astra",
@@ -53,12 +53,12 @@
         "thinking": "low"
       },
       "worker": {
-        "model": "openai-codex/gpt-6-astra",
-        "thinking": "low"
+        "model": "openai-codex/gpt-5.6-sol",
+        "thinking": "medium"
       },
       "researcher": {
-        "model": "openai-codex/gpt-5.6-luna",
-        "thinking": "max"
+        "model": "openai-codex/gpt-5.6-sol",
+        "thinking": "low"
       }
     }
   },


### PR DESCRIPTION
## Changes
- Set worker and delegate to Sol (`gpt-5.6-sol`) with medium thinking.
- Set researcher to Sol with low thinking.

## Why
I'm making this change for two reasons:

1. I've noticed Astra's code is generally not very good, so I don't want it to be the implementer model.
2. Switching researcher to Luna ended up making my research workflows take two hours. That's far too long and isn't sustainable.

Sol should be effective and much faster, while being only a little more expensive on my Codex usage.

## Validation
- JSON parsing and `git diff --check` passed.
- Pre-commit checks passed, including the Ruby test suite.
